### PR TITLE
Make sure LocalPlayer is ALWAYS defined

### DIFF
--- a/Library.lua
+++ b/Library.lua
@@ -19,7 +19,7 @@ local gethui = gethui or function()
     return CoreGui 
 end
 
-local LocalPlayer = Players.LocalPlayer
+local LocalPlayer = Players.LocalPlayer or Players.PlayerAdded:Wait()
 local Mouse = LocalPlayer:GetMouse()
 
 local Labels = {}


### PR DESCRIPTION
Fixes an issue where, when you load very slowly (or execute really early on) LocalPlayer will be nil (causing GetMouse to error)