### PR TITLE
fix: Fixed Obsidian's `Library:Validate()` function

### DIFF
--- a/Library.lua
+++ b/Library.lua
@@ -855,6 +855,10 @@ function Library:Validate(Table: { [string]: any }, Template: { [string]: any })
     end
 
     for k, v in pairs(Template) do
+        if typeof(k) == "number" then
+            continue
+        end
+
         if typeof(v) == "table" then
             Table[k] = Library:Validate(Table[k], v)
         elseif Table[k] == nil then


### PR DESCRIPTION
Fixes this issue:
```diff
 LeftGroupBox:AddLabel("Auto Gurt"):AddKeyPicker("KeyPicker", {
     Default = "MB2",
     SyncToggleState = false,
 
     Mode = "Hold",
+    Modes = { "Always", "Hold" },

     Text = "Auto Gurt",
 })
```
Causing the following unexpected issue:
![image](https://github.com/user-attachments/assets/240cb6f8-0c11-4ad6-bbe2-faa3e87eb967)

Reported initially on discord by wally