### PR TITLE
feat: modifier key support for keypickers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 5.10.2025
+
+```diff
++ Added support for modifier keys in KeyPicker (for example: LCtrl + E)
++ Fixed DoClick not calling the correct callbacks
+```
+
 ## 17.09.2025
 
 ```diff

--- a/Example.lua
+++ b/Example.lua
@@ -576,9 +576,9 @@ LeftGroupBox:AddLabel("Keybind"):AddKeyPicker("KeyPicker", {
 		print("[cb] Keybind clicked!", Value)
 	end,
 
-	-- Occurs when the keybind itself is changed, `New` is a KeyCode Enum OR a UserInputType Enum
-	ChangedCallback = function(New)
-		print("[cb] Keybind changed!", New)
+	-- Occurs when the keybind itself is changed, `NewKey` is a KeyCode Enum OR a UserInputType Enum, `NewModifiers` is a table with KeyCode Enum(s) or nil
+	ChangedCallback = function(NewKey, NewModifiers)
+		print("[cb] Keybind changed!", table.unpack(NewModifiers or {}), NewKey)
 	end,
 })
 
@@ -589,7 +589,7 @@ Options.KeyPicker:OnClick(function()
 end)
 
 Options.KeyPicker:OnChanged(function()
-	print("Keybind changed!", Options.KeyPicker.Value)
+	print("Keybind changed!", table.unpack(Options.KeyPicker.Modifiers or {}), Options.KeyPicker.Value)
 end)
 
 task.spawn(function()

--- a/Library.lua
+++ b/Library.lua
@@ -339,6 +339,7 @@ local Templates = {
     KeyPicker = {
         Text = "KeyPicker",
         Default = "None",
+        DefaultModifiers = {},
         Mode = "Toggle",
         Modes = { "Always", "Toggle", "Hold" },
         SyncToggleState = false,
@@ -1845,7 +1846,7 @@ do
             Text = Info.Text,
 
             Value = Info.Default, -- Key
-            Modifiers = {}, -- Modifiers
+            Modifiers = Info.DefaultModifiers, -- Modifiers
             DisplayValue = Info.Default, -- Picker Text
 
             Toggled = false,
@@ -2221,8 +2222,8 @@ do
         function KeyPicker:SetValue(Data)
             local Key, Mode, Modifiers = Data[1], Data[2], Data[3]
 
-            KeyPicker.Value = Key
-            KeyPicker.Modifiers = if typeof(Modifiers) == "table" then Modifiers else KeyPicker.Modifiers
+            KeyPicker.Value = Key;
+            KeyPicker.Modifiers = if typeof(Modifiers) == "table" then Modifiers else (if typeof(KeyPicker.Modifiers) == "table" then KeyPicker.Modifiers else {});
             KeyPicker.DisplayValue = if GetTableSize(KeyPicker.Modifiers) > 0 then (table.concat(KeyPicker.Modifiers, " + ") .. " + " .. KeyPicker.Value) else KeyPicker.Value;
 
             if ModeButtons[Mode] then

--- a/Library.lua
+++ b/Library.lua
@@ -1977,6 +1977,24 @@ do
             return InputModifiers;
         end
 
+        local VerifyModifiers = function(CurrentModifiers)
+            if typeof(CurrentModifiers) ~= "table" then
+                return {};
+            end;
+
+            local ValidModifiers = {};
+
+            for _, name in CurrentModifiers do
+                if not Modifiers[name] then continue end
+
+                table.insert(ValidModifiers, name);
+            end
+
+            return ValidModifiers;
+        end
+
+        KeyPicker.Modifiers = VerifyModifiers(KeyPicker.Modifiers); -- Verify default modifiers
+
         local Picker = New("TextButton", {
             BackgroundColor3 = "MainColor",
             BorderColor3 = "OutlineColor",
@@ -2223,7 +2241,7 @@ do
             local Key, Mode, Modifiers = Data[1], Data[2], Data[3]
 
             KeyPicker.Value = Key;
-            KeyPicker.Modifiers = if typeof(Modifiers) == "table" then Modifiers else (if typeof(KeyPicker.Modifiers) == "table" then KeyPicker.Modifiers else {});
+            KeyPicker.Modifiers = VerifyModifiers(if typeof(Modifiers) == "table" then Modifiers else KeyPicker.Modifiers);
             KeyPicker.DisplayValue = if GetTableSize(KeyPicker.Modifiers) > 0 then (table.concat(KeyPicker.Modifiers, " + ") .. " + " .. KeyPicker.Value) else KeyPicker.Value;
 
             if ModeButtons[Mode] then

--- a/addons/SaveManager.lua
+++ b/addons/SaveManager.lua
@@ -83,11 +83,11 @@ local SaveManager = {} do
         },
         KeyPicker = {
             Save = function(idx, object)
-                return { type = "KeyPicker", idx = idx, mode = object.Mode, key = object.Value }
+                return { type = "KeyPicker", idx = idx, mode = object.Mode, key = object.Value, modifiers = object.Modifiers }
             end,
             Load = function(idx, data)
                 if SaveManager.Library.Options[idx] then
-                    SaveManager.Library.Options[idx]:SetValue({ data.key, data.mode })
+                    SaveManager.Library.Options[idx]:SetValue({ data.key, data.mode, data.modifiers })
                 end
             end,
         },


### PR DESCRIPTION
added:
Modifier key support (currently CTRL, Shift, Alt, Tab, CapsLock) KeyPicker.Modifiers
KeyPicker.DisplayValue
DefaultModifiers option for KeyPickers (check the Modifiers inside KeyPicker for the strings)

changed:
KeyPicker:SetValue() accepts 3 arguments now (third one is modifiers) KeyPicker:SetValue() now calls the changed callbacks KeyPicker Changed Callbacks now include modifiers (NewKey, NewModifiers)

fixed:
KeyPicker:DoClick() now fires correct callbacks (Callback - KeyPicker.Callback = ..., Clicked - KeyPicker:OnClick(...))