### PR TITLE
refactor: allow modifiers to be used as a normal key

### DIFF
--- a/Example.lua
+++ b/Example.lua
@@ -1,3 +1,4 @@
+
 -- example script by https://github.com/mstudio45/LinoriaLib/blob/main/Example.lua and modified by deivid
 -- You can suggest changes with a pull request or something
 
@@ -578,7 +579,7 @@ LeftGroupBox:AddLabel("Keybind"):AddKeyPicker("KeyPicker", {
 
 	-- Occurs when the keybind itself is changed, `NewKey` is a KeyCode Enum OR a UserInputType Enum, `NewModifiers` is a table with KeyCode Enum(s) or nil
 	ChangedCallback = function(NewKey, NewModifiers)
-		print("[cb] Keybind changed!", table.unpack(NewModifiers or {}), NewKey)
+		print("[cb] Keybind changed!", NewKey, table.unpack(NewModifiers or {}))
 	end,
 })
 
@@ -589,7 +590,7 @@ Options.KeyPicker:OnClick(function()
 end)
 
 Options.KeyPicker:OnChanged(function()
-	print("Keybind changed!", table.unpack(Options.KeyPicker.Modifiers or {}), Options.KeyPicker.Value)
+	print("Keybind changed!", Options.KeyPicker.Value, table.unpack(Options.KeyPicker.Modifiers or {}))
 end)
 
 task.spawn(function()


### PR DESCRIPTION
allows multiple modifier keys
easier selection for modifiers (hold for min 0.075 seconds - apears in display text)
modifier keys can be used as a normal key