### PR TITLE
Fix AccentColor tinting for external icons + cleanup on reinject

### DIFF
--- a/Library.lua
+++ b/Library.lua
@@ -1046,23 +1046,17 @@ function Library:GiveSignal(Connection: RBXScriptConnection | RBXScriptSignal)
     return Connection
 end
 
--- Returns true for strings that are full-color Roblox image assets and should NOT be tinted with AccentColor.
--- Only matches known built-in engine texture paths (rbxasset://textures/...) and CDN thumbnails.
--- Does NOT match getcustomasset output (rbxasset://<hash>/...)
--- or rbxassetid://, both of which are user-supplied and should receive AccentColor.
 function IsValidCustomIcon(Icon: string)
-	return typeof(Icon) == "string"
-		and (
-			Icon:match("^rbxasset://textures/")
-			or Icon:match("roblox%.com/asset/%?id=")
-			or Icon:match("rbxthumb://type=")
-		)
+    return typeof(Icon) == "string"
+        and (
+            Icon:match("^rbxasset://textures/")
+            or Icon:match("roblox%.com/asset/%?id=")
+            or Icon:match("rbxthumb://type=")
+        )
 end
 
--- Returns true for file-backed icons loaded via getcustomasset.
--- Covers both content:// (some skidded executors) and rbxasset://<hash>/... (others).
 local function IsFileBackedIcon(Icon: string)
-	return typeof(Icon) == "string" and (Icon:match("^content://") or Icon:match("^rbxasset://%x+/"))
+    return typeof(Icon) == "string" and (Icon:match("^content://") or Icon:match("^rbxasset://%x+/"))
 end
 
 type Icon = {
@@ -1098,24 +1092,21 @@ function Library:GetIcon(IconName: string)
 end
 
 function Library:GetCustomIcon(IconName: string)
-	if not IconName then
+    if not IconName then
         return nil
     end
 
     if tonumber(IconName) then
         IconName = string.format("rbxassetid://%s", tostring(IconName))
     end
-	
+
     if IsFileBackedIcon(IconName) or (typeof(IconName) == "string" and IconName:match("^rbxassetid://")) then
-        -- content:// (getcustomasset) or rbxassetid:// passed directly as an icon
-        -- treat as grayscale; no Custom flag so AccentColor tinting is applied.
         return {
             Url = IconName,
             ImageRectOffset = Vector2.zero,
             ImageRectSize = Vector2.zero,
         }
     elseif IsValidCustomIcon(IconName) then
-        -- Full-color built-in asset (rbxasset://, rbxthumb://, etc.) to preserve original colors.
         return {
             Url = IconName,
             ImageRectOffset = Vector2.zero,
@@ -1225,9 +1216,7 @@ local function ParentUI(UI: Instance, SkipHiddenUI: boolean?)
     SafeParentUI(UI, gethui)
 end
 
--- Destroy previous interface instances
-
-for _, prevUI in pairs(gethui():GetChildren()) do
+for _, prevUI in gethui():GetChildren() do
     if prevUI:IsA("ScreenGui") and prevUI.Name == "Obsidian" then
         prevUI:Destroy()
     end

--- a/Library.lua
+++ b/Library.lua
@@ -1034,8 +1034,23 @@ function Library:GiveSignal(Connection: RBXScriptConnection | RBXScriptSignal)
     return Connection
 end
 
+-- Returns true for strings that are full-color Roblox image assets and should NOT be tinted with AccentColor.
+-- Only matches known built-in engine texture paths (rbxasset://textures/...) and CDN thumbnails.
+-- Does NOT match getcustomasset output (rbxasset://<hash>/...)
+-- or rbxassetid://, both of which are user-supplied and should receive AccentColor.
 function IsValidCustomIcon(Icon: string)
-    return typeof(Icon) == "string" and (Icon:match("rbxasset") or Icon:match("roblox%.com/asset/%?id=") or Icon:match("rbxthumb://type="))
+	return typeof(Icon) == "string"
+		and (
+			Icon:match("^rbxasset://textures/")
+			or Icon:match("roblox%.com/asset/%?id=")
+			or Icon:match("rbxthumb://type=")
+		)
+end
+
+-- Returns true for file-backed icons loaded via getcustomasset.
+-- Covers both content:// (some skidded executors) and rbxasset://<hash>/... (others).
+local function IsFileBackedIcon(Icon: string)
+	return typeof(Icon) == "string" and (Icon:match("^content://") or Icon:match("^rbxasset://%x+/"))
 end
 
 type Icon = {
@@ -1069,17 +1084,17 @@ function Library:GetIcon(IconName: string)
     return Icon
 end
 
-function Library:GetCustomIcon(IconName: string): any
-    if not IconName then
-        return nil
-    end
-
-    if tonumber(IconName) then
-        IconName = string.format("rbxassetid://%s", tostring(IconName))
-    end
-
-    local CustomIcon = IsValidCustomIcon(IconName)
-    if CustomIcon then
+function Library:GetCustomIcon(IconName: string)
+    if IsFileBackedIcon(IconName) or (typeof(IconName) == "string" and IconName:match("^rbxassetid://")) then
+        -- content:// (getcustomasset) or rbxassetid:// passed directly as an icon
+        -- treat as grayscale; no Custom flag so AccentColor tinting is applied.
+        return {
+            Url = IconName,
+            ImageRectOffset = Vector2.zero,
+            ImageRectSize = Vector2.zero,
+        }
+    elseif IsValidCustomIcon(IconName) then
+        -- Full-color built-in asset (rbxasset://, rbxthumb://, etc.) to preserve original colors.
         return {
             Url = IconName,
             ImageRectOffset = Vector2.zero,
@@ -1187,6 +1202,14 @@ local function ParentUI(UI: Instance, SkipHiddenUI: boolean?)
 
     pcall(protectgui, UI)
     SafeParentUI(UI, gethui)
+end
+
+-- Destroy previous interface instances
+
+for _, prevUI in pairs(gethui():GetChildren()) do
+    if prevUI:IsA("ScreenGui") and prevUI.Name == "Obsidian" then
+        prevUI:Destroy()
+    end
 end
 
 local ScreenGui = New("ScreenGui", {

--- a/Library.lua
+++ b/Library.lua
@@ -1085,6 +1085,14 @@ function Library:GetIcon(IconName: string)
 end
 
 function Library:GetCustomIcon(IconName: string)
+	if not IconName then
+        return nil
+    end
+
+    if tonumber(IconName) then
+        IconName = string.format("rbxassetid://%s", tostring(IconName))
+    end
+	
     if IsFileBackedIcon(IconName) or (typeof(IconName) == "string" and IconName:match("^rbxassetid://")) then
         -- content:// (getcustomasset) or rbxassetid:// passed directly as an icon
         -- treat as grayscale; no Custom flag so AccentColor tinting is applied.


### PR DESCRIPTION
## Changes

### Fixed `AccentColor` not being applied to externally loaded tab icons
`IsValidCustomIcon` used a bare `rbxasset` substring match, which
unintentionally caught `rbxassetid://` and `getcustomasset` paths
`(rbxasset://<hash>/...)`, marking them `Custom = true` and rendering
white instead of `AccentColor`.

Tightened the match to `^rbxasset://textures/` (built-in engine textures
only) and added `IsFileBackedIcon` to specifically handle executor
file-backed paths, routing them through the non-`Custom` branch so
`AccentColor` is applied correctly.

### Cleanup on re-inject
Any existing Obsidian ScreenGui instances will now be destroyed before
creating a new one, preventing duplicate UIs from stacking if the library is
re-injected without the game reloading.

[Check out my other pull request (closed)](https://github.com/deividcomsono/Obsidian/pull/123)