### PR TITLE
Fix search bar clear restoring hidden elements

### DIFF
--- a/Library.lua
+++ b/Library.lua
@@ -703,7 +703,7 @@ local function CheckDepbox(Box, Search)
 end
 local function RestoreDepbox(Box)
     for _, ElementInfo in Box.Elements do
-        ElementInfo.Holder.Visible = typeof(ElementInfo.Visible) == "boolean" and ElementInfo.Visible or true
+        ElementInfo.Holder.Visible = ElementInfo.Visible ~= false
 
         if ElementInfo.SubButton then
             ElementInfo.Base.Visible = ElementInfo.Visible
@@ -865,7 +865,7 @@ local function ResetTab(Tab)
 
     for _, Groupbox in Tab.Groupboxes do
         for _, ElementInfo in Groupbox.Elements do
-            ElementInfo.Holder.Visible = typeof(ElementInfo.Visible) == "boolean" and ElementInfo.Visible or true
+            ElementInfo.Holder.Visible = ElementInfo.Visible ~= false
 
             if ElementInfo.SubButton then
                 ElementInfo.Base.Visible = ElementInfo.Visible
@@ -888,7 +888,7 @@ local function ResetTab(Tab)
     for _, Tabbox in Tab.Tabboxes do
         for _, SubTab in Tabbox.Tabs do
             for _, ElementInfo in SubTab.Elements do
-                ElementInfo.Holder.Visible = typeof(ElementInfo.Visible) == "boolean" and ElementInfo.Visible or true
+                ElementInfo.Holder.Visible = ElementInfo.Visible ~= false
 
                 if ElementInfo.SubButton then
                     ElementInfo.Base.Visible = ElementInfo.Visible


### PR DESCRIPTION
When clearing the search bar, `RestoreDepbox`/`ResetTab` used `typeof(Visible) == "boolean" and Visible or true` to restore each element's previous visibility. This is a broken Lua ternary pattern — when `Visible` is `false`, the `and` arm short-circuits to `false`, causing the `or true` fallback to fire, so every hidden element was unconditionally forced visible.

<img width="502" height="156" alt="Fix search resetting element visibility" src="https://github.com/user-attachments/assets/a1eeb93c-cefa-4433-8671-4d15e386ba6e" />

Replaced all three occurrences with `ElementInfo.Visible ~= false`, which correctly restores `false` as hidden, `true` as visible, and treats `nil` (unset) as visible by default.
This also directly fixes [issue #114.](https://github.com/deividcomsono/Obsidian/issues/114)
<img width="942" height="313" alt="image" src="https://github.com/user-attachments/assets/e9d401eb-5127-447e-aac6-97d23789c33c" />