### PR TITLE
Fix SetCornerRadius skipping zero-offset and full-radius corners

### DIFF
--- a/Library.lua
+++ b/Library.lua
@@ -8279,10 +8279,6 @@ function Library:CreateWindow(WindowInfo)
 
     local function SetUICorner(UICorner, Corner, HalfCurrent, HalfValue, Value)
         local Current = UICorner[Corner]
-        if Current.Offset == 0 and Current.Scale == 0 then
-            return
-        end
-
         UICorner[Corner] = Current.Offset == HalfCurrent and HalfValue or Value
     end
 
@@ -8314,7 +8310,7 @@ function Library:CreateWindow(WindowInfo)
         Radius = math.min(Radius, 20)
 
         local RadiusHalf = UDim.new(0, Radius / 2)
-        local RadiusUDim = UDim.new(0, Radius / 2)
+        local RadiusUDim = UDim.new(0, Radius)
         local HalfCurrent = Library.CornerRadius / 2
 
         for _, UICorner in Library.Corners do


### PR DESCRIPTION
<img width="240" height="136" alt="Fix dropdowns ignoring SetCornerRadius" src="https://github.com/user-attachments/assets/cb16be34-8dfd-4f71-8438-577d0f8735fe" />

Two bugs in `SetCornerRadius`:
1. `SetUICorner` had an early-exit guard for corners with `Offset == 0`. When a dropdown is open, its bottom corners are set to `UDim.new(0, 0)` to square off against the menu — so the guard skipped them entirely, leaving them frozen at `0` after any radius change. Removed the guard so all four corner properties are always updated.

2. `RadiusHalf` and `RadiusUDim` were both set to `Radius / 2`, making them identical. `RadiusUDim` is supposed to carry the full `Radius` for corners like `MainFrame` and `SideBar` registered at full radius in `Library.Corners`. Fixed `RadiusUDim` to `UDim.new(0, Radius)`.