### PR TITLE
Add confirmation dialogs to destructive SaveManager and ThemeManager actions

### DIFF
--- a/Library.lua
+++ b/Library.lua
@@ -10345,6 +10345,7 @@ function Library:CreateWindow(WindowInfo)
         Library.IsRobloxFocused = false
     end))
 
+    Library.Window = Window
     return Window
 end
 

--- a/addons/SaveManager.lua
+++ b/addons/SaveManager.lua
@@ -428,16 +428,15 @@ local SaveManager = {} do
 
         local section = tab:AddRightGroupbox("Configuration", icon or "folder-cog")
 
-        section:AddInput("SaveManager_ConfigName",    { Text = "Config name" })
+        section:AddInput("SaveManager_ConfigName", { Text = "Config name" })
         section:AddButton("Create config", function()
             local name = self.Library.Options.SaveManager_ConfigName.Value
-
-            if name:gsub(" ", "") == "" then
+            if not name or name:gsub(" ", "") == "" then
                 self.Library:Notify("Invalid config name (empty)", 2)
                 return
             end
 
-            local function doSave()
+            local function SaveConfig()
                 local success, err = self:Save(name)
                 if not success then
                     self.Library:Notify("Failed to create config: " .. err)
@@ -449,38 +448,39 @@ local SaveManager = {} do
                 self.Library.Options.SaveManager_ConfigList:SetValue(nil)
             end
 
-            local existingConfigs = self:RefreshConfigList()
-            local alreadyExists = table.find(existingConfigs, name)
+            local ExistingConfigs = self:RefreshConfigList()
+            local AlreadyExists = table.find(ExistingConfigs, name)
 
-            if alreadyExists then
-                local Dialog
-                Dialog = self.Library.Window:AddDialog("SaveManager_CreateOverwrite", {
-                    Title = "Config already exists",
-                    Description = string.format("A config named %q already exists. Overwriting will replace it with your current settings.", name),
-                    AutoDismiss = true,
-                    FooterButtons = {
-                        Cancel = {
-                            Title = "Cancel",
-                            Variant = "Ghost",
-                            Order = 1,
-                            Callback = function()
-                                Dialog:Dismiss()
-                            end,
-                        },
-                        Overwrite = {
-                            Title = "Overwrite",
-                            Variant = "Destructive",
-                            Order = 2,
-                            Callback = function()
-                                Dialog:Dismiss()
-                                doSave()
-                            end,
-                        },
-                    },
-                })
-            else
-                doSave()
+            if not AlreadyExists then
+                SaveConfig()
+                return
             end
+
+            local Dialog; Dialog = self.Library.Window:AddDialog("SaveManager_CreateOverwrite", {
+                Title = "Config already exists",
+                Description = string.format("A config named %q already exists. Overwriting will replace it with your current settings.", name),
+                AutoDismiss = true,
+                FooterButtons = {
+                    Cancel = {
+                        Title = "Cancel",
+                        Variant = "Ghost",
+                        Order = 1,
+                        Callback = function()
+                            Dialog:Dismiss()
+                        end
+                    },
+
+                    Overwrite = {
+                        Title = "Overwrite",
+                        Variant = "Destructive",
+                        Order = 2,
+                        Callback = function()
+                            Dialog:Dismiss()
+                            SaveConfig()
+                        end
+                    }
+                }
+            })
         end)
 
         section:AddDivider()
@@ -488,7 +488,7 @@ local SaveManager = {} do
         section:AddDropdown("SaveManager_ConfigList", { Text = "Config list", Values = self:RefreshConfigList(), AllowNull = true })
         section:AddButton("Load config", function()
             local name = self.Library.Options.SaveManager_ConfigList.Value
-            if not name or name == "" then
+            if not name or name:gsub(" ", "") == "" then
                 self.Library:Notify("No config selected", 2)
                 return
             end
@@ -503,13 +503,12 @@ local SaveManager = {} do
         end)
         section:AddButton("Overwrite config", function()
             local name = self.Library.Options.SaveManager_ConfigList.Value
-            if not name or name == "" then
+            if not name or name:gsub(" ", "") == "" then
                 self.Library:Notify("No config selected", 2)
                 return
             end
 
-            local Dialog
-            Dialog = self.Library.Window:AddDialog("SaveManager_OverwriteConfig", {
+            local Dialog; Dialog = self.Library.Window:AddDialog("SaveManager_OverwriteConfig", {
                 Title = "Overwrite config",
                 Description = string.format("Are you sure you want to overwrite %q with your current settings? This cannot be undone.", name),
                 AutoDismiss = true,
@@ -520,14 +519,16 @@ local SaveManager = {} do
                         Order = 1,
                         Callback = function()
                             Dialog:Dismiss()
-                        end,
+                        end
                     },
+
                     Overwrite = {
                         Title = "Overwrite",
                         Variant = "Destructive",
                         Order = 2,
                         Callback = function()
                             Dialog:Dismiss()
+
                             local success, err = self:Save(name)
                             if not success then
                                 self.Library:Notify("Failed to overwrite config: " .. err)
@@ -535,21 +536,20 @@ local SaveManager = {} do
                             end
 
                             self.Library:Notify(string.format("Overwrote config %q", name))
-                        end,
-                    },
-                },
+                        end
+                    }
+                }
             })
         end)
 
         section:AddButton("Delete config", function()
             local name = self.Library.Options.SaveManager_ConfigList.Value
-            if not name or name == "" then
+            if not name or name:gsub(" ", "") == "" then
                 self.Library:Notify("No config selected", 2)
                 return
             end
 
-            local Dialog
-            Dialog = self.Library.Window:AddDialog("SaveManager_DeleteConfig", {
+            local Dialog; Dialog = self.Library.Window:AddDialog("SaveManager_DeleteConfig", {
                 Title = "Delete config",
                 Description = string.format("Are you sure you want to delete %q? This cannot be undone.", name),
                 AutoDismiss = true,
@@ -560,14 +560,16 @@ local SaveManager = {} do
                         Order = 1,
                         Callback = function()
                             Dialog:Dismiss()
-                        end,
+                        end
                     },
+
                     Delete = {
                         Title = "Delete",
                         Variant = "Destructive",
                         Order = 2,
                         Callback = function()
                             Dialog:Dismiss()
+
                             local success, err = self:Delete(name)
                             if not success then
                                 self.Library:Notify("Failed to delete config: " .. err)
@@ -577,9 +579,9 @@ local SaveManager = {} do
                             self.Library:Notify(string.format("Deleted config %q", name))
                             self.Library.Options.SaveManager_ConfigList:SetValues(self:RefreshConfigList())
                             self.Library.Options.SaveManager_ConfigList:SetValue(nil)
-                        end,
-                    },
-                },
+                        end
+                    }
+                }
             })
         end)
 
@@ -590,7 +592,7 @@ local SaveManager = {} do
 
         section:AddButton("Set as autoload", function()
             local name = self.Library.Options.SaveManager_ConfigList.Value
-            if not name or name == "" then
+            if not name or name:gsub(" ", "") == "" then
                 self.Library:Notify("No config selected", 2)
                 return
             end
@@ -604,9 +606,9 @@ local SaveManager = {} do
             self.Library:Notify(string.format("Set %q to auto load", name))
             self.AutoloadConfigLabel:SetText("Current autoload config: " .. name)
         end)
+
         section:AddButton("Reset autoload", function()
-            local Dialog
-            Dialog = self.Library.Window:AddDialog("SaveManager_ResetAutoload", {
+            local Dialog; Dialog = self.Library.Window:AddDialog("SaveManager_ResetAutoload", {
                 Title = "Reset autoload config",
                 Description = "Are you sure you want to clear the autoload config? No config will be loaded automatically on next launch.",
                 AutoDismiss = true,
@@ -617,14 +619,16 @@ local SaveManager = {} do
                         Order = 1,
                         Callback = function()
                             Dialog:Dismiss()
-                        end,
+                        end
                     },
+
                     Reset = {
                         Title = "Reset",
                         Variant = "Destructive",
                         Order = 2,
                         Callback = function()
                             Dialog:Dismiss()
+
                             local success, err = self:DeleteAutoLoadConfig()
                             if not success then
                                 self.Library:Notify("Failed to set autoload config: " .. err)
@@ -633,15 +637,13 @@ local SaveManager = {} do
 
                             self.Library:Notify("Set autoload to none")
                             self.AutoloadConfigLabel:SetText("Current autoload config: none")
-                        end,
-                    },
-                },
+                        end
+                    }
+                }
             })
         end)
 
         self.AutoloadConfigLabel = section:AddLabel("Current autoload config: " .. self:GetAutoloadConfig(), true)
-
-        -- self:LoadAutoloadConfig()
         self:SetIgnoreIndexes({ "SaveManager_ConfigList", "SaveManager_ConfigName" })
     end
 

--- a/addons/SaveManager.lua
+++ b/addons/SaveManager.lua
@@ -456,7 +456,7 @@ local SaveManager = {} do
                 return
             end
 
-            local Dialog; Dialog = self.Library.Window:AddDialog("SaveManager_CreateOverwrite", {
+            self.Library.Window:AddDialog("SaveManager_CreateOverwrite", {
                 Title = "Config already exists",
                 Description = string.format("A config named %q already exists. Overwriting will replace it with your current settings.", name),
                 AutoDismiss = true,
@@ -465,7 +465,7 @@ local SaveManager = {} do
                         Title = "Cancel",
                         Variant = "Ghost",
                         Order = 1,
-                        Callback = function()
+                        Callback = function(Dialog)
                             Dialog:Dismiss()
                         end
                     },
@@ -474,7 +474,7 @@ local SaveManager = {} do
                         Title = "Overwrite",
                         Variant = "Destructive",
                         Order = 2,
-                        Callback = function()
+                        Callback = function(Dialog)
                             Dialog:Dismiss()
                             SaveConfig()
                         end
@@ -508,7 +508,7 @@ local SaveManager = {} do
                 return
             end
 
-            local Dialog; Dialog = self.Library.Window:AddDialog("SaveManager_OverwriteConfig", {
+            self.Library.Window:AddDialog("SaveManager_OverwriteConfig", {
                 Title = "Overwrite config",
                 Description = string.format("Are you sure you want to overwrite %q with your current settings? This cannot be undone.", name),
                 AutoDismiss = true,
@@ -517,7 +517,7 @@ local SaveManager = {} do
                         Title = "Cancel",
                         Variant = "Ghost",
                         Order = 1,
-                        Callback = function()
+                        Callback = function(Dialog)
                             Dialog:Dismiss()
                         end
                     },
@@ -526,7 +526,7 @@ local SaveManager = {} do
                         Title = "Overwrite",
                         Variant = "Destructive",
                         Order = 2,
-                        Callback = function()
+                        Callback = function(Dialog)
                             Dialog:Dismiss()
 
                             local success, err = self:Save(name)
@@ -549,7 +549,7 @@ local SaveManager = {} do
                 return
             end
 
-            local Dialog; Dialog = self.Library.Window:AddDialog("SaveManager_DeleteConfig", {
+            self.Library.Window:AddDialog("SaveManager_DeleteConfig", {
                 Title = "Delete config",
                 Description = string.format("Are you sure you want to delete %q? This cannot be undone.", name),
                 AutoDismiss = true,
@@ -558,7 +558,7 @@ local SaveManager = {} do
                         Title = "Cancel",
                         Variant = "Ghost",
                         Order = 1,
-                        Callback = function()
+                        Callback = function(Dialog)
                             Dialog:Dismiss()
                         end
                     },
@@ -567,7 +567,7 @@ local SaveManager = {} do
                         Title = "Delete",
                         Variant = "Destructive",
                         Order = 2,
-                        Callback = function()
+                        Callback = function(Dialog)
                             Dialog:Dismiss()
 
                             local success, err = self:Delete(name)
@@ -606,9 +606,8 @@ local SaveManager = {} do
             self.Library:Notify(string.format("Set %q to auto load", name))
             self.AutoloadConfigLabel:SetText("Current autoload config: " .. name)
         end)
-
         section:AddButton("Reset autoload", function()
-            local Dialog; Dialog = self.Library.Window:AddDialog("SaveManager_ResetAutoload", {
+            self.Library.Window:AddDialog("SaveManager_ResetAutoload", {
                 Title = "Reset autoload config",
                 Description = "Are you sure you want to clear the autoload config? No config will be loaded automatically on next launch.",
                 AutoDismiss = true,
@@ -617,7 +616,7 @@ local SaveManager = {} do
                         Title = "Cancel",
                         Variant = "Ghost",
                         Order = 1,
-                        Callback = function()
+                        Callback = function(Dialog)
                             Dialog:Dismiss()
                         end
                     },
@@ -626,7 +625,7 @@ local SaveManager = {} do
                         Title = "Reset",
                         Variant = "Destructive",
                         Order = 2,
-                        Callback = function()
+                        Callback = function(Dialog)
                             Dialog:Dismiss()
 
                             local success, err = self:DeleteAutoLoadConfig()

--- a/addons/SaveManager.lua
+++ b/addons/SaveManager.lua
@@ -437,15 +437,50 @@ local SaveManager = {} do
                 return
             end
 
-            local success, err = self:Save(name)
-            if not success then
-                self.Library:Notify("Failed to create config: " .. err)
-                return
+            local function doSave()
+                local success, err = self:Save(name)
+                if not success then
+                    self.Library:Notify("Failed to create config: " .. err)
+                    return
+                end
+
+                self.Library:Notify(string.format("Created config %q", name))
+                self.Library.Options.SaveManager_ConfigList:SetValues(self:RefreshConfigList())
+                self.Library.Options.SaveManager_ConfigList:SetValue(nil)
             end
 
-            self.Library:Notify(string.format("Created config %q", name))
-            self.Library.Options.SaveManager_ConfigList:SetValues(self:RefreshConfigList())
-            self.Library.Options.SaveManager_ConfigList:SetValue(nil)
+            local existingConfigs = self:RefreshConfigList()
+            local alreadyExists = table.find(existingConfigs, name)
+
+            if alreadyExists then
+                local Dialog
+                Dialog = self.Library.Window:AddDialog("SaveManager_CreateOverwrite", {
+                    Title = "Config already exists",
+                    Description = string.format("A config named %q already exists. Overwriting will replace it with your current settings.", name),
+                    AutoDismiss = true,
+                    FooterButtons = {
+                        Cancel = {
+                            Title = "Cancel",
+                            Variant = "Ghost",
+                            Order = 1,
+                            Callback = function()
+                                Dialog:Dismiss()
+                            end,
+                        },
+                        Overwrite = {
+                            Title = "Overwrite",
+                            Variant = "Destructive",
+                            Order = 2,
+                            Callback = function()
+                                Dialog:Dismiss()
+                                doSave()
+                            end,
+                        },
+                    },
+                })
+            else
+                doSave()
+            end
         end)
 
         section:AddDivider()
@@ -453,6 +488,10 @@ local SaveManager = {} do
         section:AddDropdown("SaveManager_ConfigList", { Text = "Config list", Values = self:RefreshConfigList(), AllowNull = true })
         section:AddButton("Load config", function()
             local name = self.Library.Options.SaveManager_ConfigList.Value
+            if not name or name == "" then
+                self.Library:Notify("No config selected", 2)
+                return
+            end
 
             local success, err = self:Load(name)
             if not success then
@@ -464,28 +503,84 @@ local SaveManager = {} do
         end)
         section:AddButton("Overwrite config", function()
             local name = self.Library.Options.SaveManager_ConfigList.Value
-
-            local success, err = self:Save(name)
-            if not success then
-                self.Library:Notify("Failed to overwrite config: " .. err)
+            if not name or name == "" then
+                self.Library:Notify("No config selected", 2)
                 return
             end
 
-            self.Library:Notify(string.format("Overwrote config %q", name))
+            local Dialog
+            Dialog = self.Library.Window:AddDialog("SaveManager_OverwriteConfig", {
+                Title = "Overwrite config",
+                Description = string.format("Are you sure you want to overwrite %q with your current settings? This cannot be undone.", name),
+                AutoDismiss = true,
+                FooterButtons = {
+                    Cancel = {
+                        Title = "Cancel",
+                        Variant = "Ghost",
+                        Order = 1,
+                        Callback = function()
+                            Dialog:Dismiss()
+                        end,
+                    },
+                    Overwrite = {
+                        Title = "Overwrite",
+                        Variant = "Destructive",
+                        Order = 2,
+                        Callback = function()
+                            Dialog:Dismiss()
+                            local success, err = self:Save(name)
+                            if not success then
+                                self.Library:Notify("Failed to overwrite config: " .. err)
+                                return
+                            end
+
+                            self.Library:Notify(string.format("Overwrote config %q", name))
+                        end,
+                    },
+                },
+            })
         end)
 
         section:AddButton("Delete config", function()
             local name = self.Library.Options.SaveManager_ConfigList.Value
-
-            local success, err = self:Delete(name)
-            if not success then
-                self.Library:Notify("Failed to delete config: " .. err)
+            if not name or name == "" then
+                self.Library:Notify("No config selected", 2)
                 return
             end
 
-            self.Library:Notify(string.format("Deleted config %q", name))
-            self.Library.Options.SaveManager_ConfigList:SetValues(self:RefreshConfigList())
-            self.Library.Options.SaveManager_ConfigList:SetValue(nil)
+            local Dialog
+            Dialog = self.Library.Window:AddDialog("SaveManager_DeleteConfig", {
+                Title = "Delete config",
+                Description = string.format("Are you sure you want to delete %q? This cannot be undone.", name),
+                AutoDismiss = true,
+                FooterButtons = {
+                    Cancel = {
+                        Title = "Cancel",
+                        Variant = "Ghost",
+                        Order = 1,
+                        Callback = function()
+                            Dialog:Dismiss()
+                        end,
+                    },
+                    Delete = {
+                        Title = "Delete",
+                        Variant = "Destructive",
+                        Order = 2,
+                        Callback = function()
+                            Dialog:Dismiss()
+                            local success, err = self:Delete(name)
+                            if not success then
+                                self.Library:Notify("Failed to delete config: " .. err)
+                                return
+                            end
+
+                            self.Library:Notify(string.format("Deleted config %q", name))
+                            self.Library.Options.SaveManager_ConfigList:SetValues(self:RefreshConfigList())
+                            self.Library.Options.SaveManager_ConfigList:SetValue(nil)
+                        end,
+                    },
+                },
+            })
         end)
 
         section:AddButton("Refresh list", function()
@@ -495,6 +590,10 @@ local SaveManager = {} do
 
         section:AddButton("Set as autoload", function()
             local name = self.Library.Options.SaveManager_ConfigList.Value
+            if not name or name == "" then
+                self.Library:Notify("No config selected", 2)
+                return
+            end
 
             local success, err = self:SaveAutoloadConfig(name)
             if not success then
@@ -506,14 +605,38 @@ local SaveManager = {} do
             self.AutoloadConfigLabel:SetText("Current autoload config: " .. name)
         end)
         section:AddButton("Reset autoload", function()
-            local success, err = self:DeleteAutoLoadConfig()
-            if not success then
-                self.Library:Notify("Failed to set autoload config: " .. err)
-                return
-            end
+            local Dialog
+            Dialog = self.Library.Window:AddDialog("SaveManager_ResetAutoload", {
+                Title = "Reset autoload config",
+                Description = "Are you sure you want to clear the autoload config? No config will be loaded automatically on next launch.",
+                AutoDismiss = true,
+                FooterButtons = {
+                    Cancel = {
+                        Title = "Cancel",
+                        Variant = "Ghost",
+                        Order = 1,
+                        Callback = function()
+                            Dialog:Dismiss()
+                        end,
+                    },
+                    Reset = {
+                        Title = "Reset",
+                        Variant = "Destructive",
+                        Order = 2,
+                        Callback = function()
+                            Dialog:Dismiss()
+                            local success, err = self:DeleteAutoLoadConfig()
+                            if not success then
+                                self.Library:Notify("Failed to set autoload config: " .. err)
+                                return
+                            end
 
-            self.Library:Notify("Set autoload to none")
-            self.AutoloadConfigLabel:SetText("Current autoload config: none")
+                            self.Library:Notify("Set autoload to none")
+                            self.AutoloadConfigLabel:SetText("Current autoload config: none")
+                        end,
+                    },
+                },
+            })
         end)
 
         self.AutoloadConfigLabel = section:AddLabel("Current autoload config: " .. self:GetAutoloadConfig(), true)

--- a/addons/ThemeManager.lua
+++ b/addons/ThemeManager.lua
@@ -403,48 +403,49 @@ do
         groupbox:AddInput("ThemeManager_CustomThemeName", { Text = "Custom theme name" })
         groupbox:AddButton("Create theme", function()
             local name = self.Library.Options.ThemeManager_CustomThemeName.Value
-
-            if name:gsub(" ", "") == "" then
+            if not name or name:gsub(" ", "") == "" then
                 self.Library:Notify("Invalid theme name (empty)", 2)
                 return
             end
 
-            local function doSave()
+            local function SaveTheme()
                 self:SaveCustomTheme(name)
+
                 self.Library:Notify(string.format("Created theme %q", name))
                 self.Library.Options.ThemeManager_CustomThemeList:SetValues(self:ReloadCustomThemes())
                 self.Library.Options.ThemeManager_CustomThemeList:SetValue(nil)
             end
 
-            if self:GetCustomTheme(name) then
-                local Dialog
-                Dialog = self.Library.Window:AddDialog("ThemeManager_CreateOverwrite", {
-                    Title = "Theme already exists",
-                    Description = string.format("A custom theme named %q already exists. Overwriting will replace it with your current colors.", name),
-                    AutoDismiss = true,
-                    FooterButtons = {
-                        Cancel = {
-                            Title = "Cancel",
-                            Variant = "Ghost",
-                            Order = 1,
-                            Callback = function()
-                                Dialog:Dismiss()
-                            end,
-                        },
-                        Overwrite = {
-                            Title = "Overwrite",
-                            Variant = "Destructive",
-                            Order = 2,
-                            Callback = function()
-                                Dialog:Dismiss()
-                                doSave()
-                            end,
-                        },
-                    },
-                })
-            else
-                doSave()
+            if not self:GetCustomTheme(name) then
+                SaveTheme()
+                return
             end
+
+            self.Library.Window:AddDialog("ThemeManager_CreateOverwrite", {
+                Title = "Theme already exists",
+                Description = string.format("A custom theme named %q already exists. Overwriting will replace it with your current colors.", name),
+                AutoDismiss = true,
+                FooterButtons = {
+                    Cancel = {
+                        Title = "Cancel",
+                        Variant = "Ghost",
+                        Order = 1,
+                        Callback = function(Dialog)
+                            Dialog:Dismiss()
+                        end
+                    },
+
+                    Overwrite = {
+                        Title = "Overwrite",
+                        Variant = "Destructive",
+                        Order = 2,
+                        Callback = function(Dialog)
+                            Dialog:Dismiss()
+                            SaveTheme()
+                        end
+                    }
+                },
+            })
         end)
 
         groupbox:AddDivider()
@@ -455,7 +456,7 @@ do
         )
         groupbox:AddButton("Load theme", function()
             local name = self.Library.Options.ThemeManager_CustomThemeList.Value
-            if not name or name == "" then
+            if not name or name:gsub(" ", "") == "" then
                 self.Library:Notify("No theme selected", 2)
                 return
             end
@@ -465,13 +466,12 @@ do
         end)
         groupbox:AddButton("Overwrite theme", function()
             local name = self.Library.Options.ThemeManager_CustomThemeList.Value
-            if not name or name == "" then
+            if not name or name:gsub(" ", "") == "" then
                 self.Library:Notify("No theme selected", 2)
                 return
             end
 
-            local Dialog
-            Dialog = self.Library.Window:AddDialog("ThemeManager_OverwriteTheme", {
+            self.Library.Window:AddDialog("ThemeManager_OverwriteTheme", {
                 Title = "Overwrite theme",
                 Description = string.format("Are you sure you want to overwrite %q with your current colors? This cannot be undone.", name),
                 AutoDismiss = true,
@@ -480,32 +480,33 @@ do
                         Title = "Cancel",
                         Variant = "Ghost",
                         Order = 1,
-                        Callback = function()
+                        Callback = function(Dialog)
                             Dialog:Dismiss()
-                        end,
+                        end
                     },
+
                     Overwrite = {
                         Title = "Overwrite",
                         Variant = "Destructive",
                         Order = 2,
-                        Callback = function()
+                        Callback = function(Dialog)
                             Dialog:Dismiss()
+
                             self:SaveCustomTheme(name)
                             self.Library:Notify(string.format("Overwrote config %q", name))
-                        end,
-                    },
-                },
+                        end
+                    }
+                }
             })
         end)
         groupbox:AddButton("Delete theme", function()
             local name = self.Library.Options.ThemeManager_CustomThemeList.Value
-            if not name or name == "" then
+            if not name or name:gsub(" ", "") == "" then
                 self.Library:Notify("No theme selected", 2)
                 return
             end
 
-            local Dialog
-            Dialog = self.Library.Window:AddDialog("ThemeManager_DeleteTheme", {
+            self.Library.Window:AddDialog("ThemeManager_DeleteTheme", {
                 Title = "Delete theme",
                 Description = string.format("Are you sure you want to delete %q? This cannot be undone.", name),
                 AutoDismiss = true,
@@ -514,16 +515,18 @@ do
                         Title = "Cancel",
                         Variant = "Ghost",
                         Order = 1,
-                        Callback = function()
+                        Callback = function(Dialog)
                             Dialog:Dismiss()
-                        end,
+                        end
                     },
+
                     Delete = {
                         Title = "Delete",
                         Variant = "Destructive",
                         Order = 2,
-                        Callback = function()
+                        Callback = function(Dialog)
                             Dialog:Dismiss()
+
                             local success, err = self:Delete(name)
                             if not success then
                                 self.Library:Notify("Failed to delete theme: " .. err)
@@ -533,9 +536,9 @@ do
                             self.Library:Notify(string.format("Deleted theme %q", name))
                             self.Library.Options.ThemeManager_CustomThemeList:SetValues(self:ReloadCustomThemes())
                             self.Library.Options.ThemeManager_CustomThemeList:SetValue(nil)
-                        end,
-                    },
-                },
+                        end
+                    }
+                }
             })
         end)
         groupbox:AddButton("Refresh list", function()
@@ -543,19 +546,17 @@ do
             self.Library.Options.ThemeManager_CustomThemeList:SetValue(nil)
         end)
         groupbox:AddButton("Set as default", function()
-            if
-                self.Library.Options.ThemeManager_CustomThemeList.Value ~= nil
-                and self.Library.Options.ThemeManager_CustomThemeList.Value ~= ""
-            then
-                self:SaveDefault(self.Library.Options.ThemeManager_CustomThemeList.Value)
-                self.Library:Notify(
-                    string.format("Set default theme to %q", self.Library.Options.ThemeManager_CustomThemeList.Value)
-                )
+            local name = self.Library.Options.ThemeManager_CustomThemeList.Value
+            if not name or name:gsub(" ", "") == "" then
+                self.Library:Notify("No theme selected", 2)
+                return
             end
+
+            self:SaveDefault(name)
+            self.Library:Notify(string.format("Set default theme to %q", name))
         end)
         groupbox:AddButton("Reset default", function()
-            local Dialog
-            Dialog = self.Library.Window:AddDialog("ThemeManager_ResetDefault", {
+            self.Library.Window:AddDialog("ThemeManager_ResetDefault", {
                 Title = "Reset default theme",
                 Description = "Are you sure you want to clear the default theme? The library will revert to its built-in default on next load.",
                 AutoDismiss = true,
@@ -564,16 +565,18 @@ do
                         Title = "Cancel",
                         Variant = "Ghost",
                         Order = 1,
-                        Callback = function()
+                        Callback = function(Dialog)
                             Dialog:Dismiss()
-                        end,
+                        end
                     },
+
                     Reset = {
                         Title = "Reset",
                         Variant = "Destructive",
                         Order = 2,
-                        Callback = function()
+                        Callback = function(Dialog)
                             Dialog:Dismiss()
+
                             local success = pcall(delfile, self.Folder .. "/themes/default.txt")
                             if not success then
                                 self.Library:Notify("Failed to reset default: delete file error")
@@ -583,9 +586,9 @@ do
                             self.Library:Notify("Set default theme to nothing")
                             self.Library.Options.ThemeManager_CustomThemeList:SetValues(self:ReloadCustomThemes())
                             self.Library.Options.ThemeManager_CustomThemeList:SetValue(nil)
-                        end,
-                    },
-                },
+                        end
+                    }
+                }
             })
         end)
 

--- a/addons/ThemeManager.lua
+++ b/addons/ThemeManager.lua
@@ -405,11 +405,42 @@ do
                 return
             end
 
-            self:SaveCustomTheme(name)
+            local function doSave()
+                self:SaveCustomTheme(name)
+                self.Library:Notify(string.format("Created theme %q", name))
+                self.Library.Options.ThemeManager_CustomThemeList:SetValues(self:ReloadCustomThemes())
+                self.Library.Options.ThemeManager_CustomThemeList:SetValue(nil)
+            end
 
-            self.Library:Notify(string.format("Created theme %q", name))
-            self.Library.Options.ThemeManager_CustomThemeList:SetValues(self:ReloadCustomThemes())
-            self.Library.Options.ThemeManager_CustomThemeList:SetValue(nil)
+            if self:GetCustomTheme(name) then
+                local Dialog
+                Dialog = self.Library.Window:AddDialog("ThemeManager_CreateOverwrite", {
+                    Title = "Theme already exists",
+                    Description = string.format("A custom theme named %q already exists. Overwriting will replace it with your current colors.", name),
+                    AutoDismiss = true,
+                    FooterButtons = {
+                        Cancel = {
+                            Title = "Cancel",
+                            Variant = "Ghost",
+                            Order = 1,
+                            Callback = function()
+                                Dialog:Dismiss()
+                            end,
+                        },
+                        Overwrite = {
+                            Title = "Overwrite",
+                            Variant = "Destructive",
+                            Order = 2,
+                            Callback = function()
+                                Dialog:Dismiss()
+                                doSave()
+                            end,
+                        },
+                    },
+                })
+            else
+                doSave()
+            end
         end)
 
         groupbox:AddDivider()
@@ -420,28 +451,88 @@ do
         )
         groupbox:AddButton("Load theme", function()
             local name = self.Library.Options.ThemeManager_CustomThemeList.Value
+            if not name or name == "" then
+                self.Library:Notify("No theme selected", 2)
+                return
+            end
 
             self:ApplyTheme(name)
             self.Library:Notify(string.format("Loaded theme %q", name))
         end)
         groupbox:AddButton("Overwrite theme", function()
             local name = self.Library.Options.ThemeManager_CustomThemeList.Value
-
-            self:SaveCustomTheme(name)
-            self.Library:Notify(string.format("Overwrote config %q", name))
-        end)
-        groupbox:AddButton("Delete theme", function()
-            local name = self.Library.Options.ThemeManager_CustomThemeList.Value
-
-            local success, err = self:Delete(name)
-            if not success then
-                self.Library:Notify("Failed to delete theme: " .. err)
+            if not name or name == "" then
+                self.Library:Notify("No theme selected", 2)
                 return
             end
 
-            self.Library:Notify(string.format("Deleted theme %q", name))
-            self.Library.Options.ThemeManager_CustomThemeList:SetValues(self:ReloadCustomThemes())
-            self.Library.Options.ThemeManager_CustomThemeList:SetValue(nil)
+            local Dialog
+            Dialog = self.Library.Window:AddDialog("ThemeManager_OverwriteTheme", {
+                Title = "Overwrite theme",
+                Description = string.format("Are you sure you want to overwrite %q with your current colors? This cannot be undone.", name),
+                AutoDismiss = true,
+                FooterButtons = {
+                    Cancel = {
+                        Title = "Cancel",
+                        Variant = "Ghost",
+                        Order = 1,
+                        Callback = function()
+                            Dialog:Dismiss()
+                        end,
+                    },
+                    Overwrite = {
+                        Title = "Overwrite",
+                        Variant = "Destructive",
+                        Order = 2,
+                        Callback = function()
+                            Dialog:Dismiss()
+                            self:SaveCustomTheme(name)
+                            self.Library:Notify(string.format("Overwrote config %q", name))
+                        end,
+                    },
+                },
+            })
+        end)
+        groupbox:AddButton("Delete theme", function()
+            local name = self.Library.Options.ThemeManager_CustomThemeList.Value
+            if not name or name == "" then
+                self.Library:Notify("No theme selected", 2)
+                return
+            end
+
+            local Dialog
+            Dialog = self.Library.Window:AddDialog("ThemeManager_DeleteTheme", {
+                Title = "Delete theme",
+                Description = string.format("Are you sure you want to delete %q? This cannot be undone.", name),
+                AutoDismiss = true,
+                FooterButtons = {
+                    Cancel = {
+                        Title = "Cancel",
+                        Variant = "Ghost",
+                        Order = 1,
+                        Callback = function()
+                            Dialog:Dismiss()
+                        end,
+                    },
+                    Delete = {
+                        Title = "Delete",
+                        Variant = "Destructive",
+                        Order = 2,
+                        Callback = function()
+                            Dialog:Dismiss()
+                            local success, err = self:Delete(name)
+                            if not success then
+                                self.Library:Notify("Failed to delete theme: " .. err)
+                                return
+                            end
+
+                            self.Library:Notify(string.format("Deleted theme %q", name))
+                            self.Library.Options.ThemeManager_CustomThemeList:SetValues(self:ReloadCustomThemes())
+                            self.Library.Options.ThemeManager_CustomThemeList:SetValue(nil)
+                        end,
+                    },
+                },
+            })
         end)
         groupbox:AddButton("Refresh list", function()
             self.Library.Options.ThemeManager_CustomThemeList:SetValues(self:ReloadCustomThemes())
@@ -459,15 +550,39 @@ do
             end
         end)
         groupbox:AddButton("Reset default", function()
-            local success = pcall(delfile, self.Folder .. "/themes/default.txt")
-            if not success then
-                self.Library:Notify("Failed to reset default: delete file error")
-                return
-            end
+            local Dialog
+            Dialog = self.Library.Window:AddDialog("ThemeManager_ResetDefault", {
+                Title = "Reset default theme",
+                Description = "Are you sure you want to clear the default theme? The library will revert to its built-in default on next load.",
+                AutoDismiss = true,
+                FooterButtons = {
+                    Cancel = {
+                        Title = "Cancel",
+                        Variant = "Ghost",
+                        Order = 1,
+                        Callback = function()
+                            Dialog:Dismiss()
+                        end,
+                    },
+                    Reset = {
+                        Title = "Reset",
+                        Variant = "Destructive",
+                        Order = 2,
+                        Callback = function()
+                            Dialog:Dismiss()
+                            local success = pcall(delfile, self.Folder .. "/themes/default.txt")
+                            if not success then
+                                self.Library:Notify("Failed to reset default: delete file error")
+                                return
+                            end
 
-            self.Library:Notify("Set default theme to nothing")
-            self.Library.Options.ThemeManager_CustomThemeList:SetValues(self:ReloadCustomThemes())
-            self.Library.Options.ThemeManager_CustomThemeList:SetValue(nil)
+                            self.Library:Notify("Set default theme to nothing")
+                            self.Library.Options.ThemeManager_CustomThemeList:SetValues(self:ReloadCustomThemes())
+                            self.Library.Options.ThemeManager_CustomThemeList:SetValue(nil)
+                        end,
+                    },
+                },
+            })
         end)
 
         self:LoadDefault()


### PR DESCRIPTION
Destructive and irreversible actions (overwrite, delete, reset) in `SaveManager` and `ThemeManager` previously executed immediately on click with no confirmation step, making accidental data loss easy.

`Window:AddDialog` is now used to gate these actions behind a **Cancel** (Ghost) & action (Destructive) prompt:

- **ThemeManager:** Create theme (name collision only), Overwrite theme, Delete theme, Reset default theme

- **SaveManager:** Create config (name collision only), Overwrite config, Delete config, Reset autoload config

For Create theme/config, the dialog only appears when the entered name already exists — a silent overwrite would otherwise occur. For all other destructive buttons, the dialog always appears.

`Library.Window` is now stored on the `Library` object at the end of `CreateWindow` so addons can reach `AddDialog` via `self.Library.Window` without requiring a separate reference to be passed in.

## Screenshots
### `ThemeManager`
<img width="408" height="150" alt="image" src="https://github.com/user-attachments/assets/f65f956e-077c-49c9-a9a2-85b63a822540" />
<img width="405" height="147" alt="image" src="https://github.com/user-attachments/assets/9c54029d-925b-4438-aa70-197049e35a13" />
<img width="406" height="149" alt="image" src="https://github.com/user-attachments/assets/1e6555a5-5512-439f-b623-9f221cd56641" />
<img width="407" height="148" alt="image" src="https://github.com/user-attachments/assets/740cdd0d-6dfb-4c9b-ad49-c48d93838d7c" />

### `SaveManager`
<img width="407" height="148" alt="image" src="https://github.com/user-attachments/assets/0f6f81ed-b713-4249-b9e6-1ff16d5d5dae" />
<img width="408" height="150" alt="image" src="https://github.com/user-attachments/assets/02b0699b-0f16-4681-818d-8b7643640099" />
<img width="408" height="149" alt="image" src="https://github.com/user-attachments/assets/e66e9802-1cad-42c4-9cf0-3f56124f054a" />
<img width="406" height="147" alt="image" src="https://github.com/user-attachments/assets/dd644213-3223-40d4-b384-6111fa5bf06e" />