### PR TITLE
Add GroupBox:SetVisible() and default visibility argument

### DIFF
--- a/Library.lua
+++ b/Library.lua
@@ -735,8 +735,8 @@ local function ApplySearchToTab(Tab, Search)
         if Groupbox.Visible == false then
             continue
         end
-        local VisibleElements = 0
 
+        local VisibleElements = 0
         for _, ElementInfo in Groupbox.Elements do
             if ElementInfo.Type == "Divider" then
                 ElementInfo.Holder.Visible = false
@@ -757,6 +757,7 @@ local function ApplySearchToTab(Tab, Search)
                     ElementInfo.SubButton.Base.Visible = false
                 end
                 ElementInfo.Holder.Visible = Visible
+
                 if Visible then
                     VisibleElements += 1
                 end
@@ -8882,6 +8883,7 @@ function Library:CreateWindow(WindowInfo)
             local Groupbox = {
                 Connections = {},
                 Destroyed = false,
+                Visible = true,
 
                 BoxHolder = BoxHolder,
                 Holder = GroupboxHolder,
@@ -8889,14 +8891,8 @@ function Library:CreateWindow(WindowInfo)
 
                 Tab = Tab,
                 DependencyBoxes = {},
-                Elements = {},
-                Visible = true,
+                Elements = {}
             }
-
-            function Groupbox:SetVisible(Visible)
-                self.Visible = Visible
-                self.BoxHolder.Visible = Visible
-            end
 
             function Groupbox:Resize()
                 GroupboxHolder.Size = UDim2.new(1, 0, 0, (GroupboxList.AbsoluteContentSize.Y / Library.DPIScale) + 49)
@@ -8934,14 +8930,31 @@ function Library:CreateWindow(WindowInfo)
                 end
             end
 
+            function Groupbox:SetVisible(Visible)
+                Groupbox.Visible = Visible
+                BoxHolder.Visible = Visible
+
+                if Visible == true and Library.Searching then
+                    Library:UpdateSearch(Library.SearchText)
+                end
+            end
+
+            function Groupbox:Show()
+                Groupbox:SetVisible(true) 
+            end
+
+            function Groupbox:Hide()
+                Groupbox:SetVisible(false) 
+            end
+
             setmetatable(Groupbox, BaseGroupbox)
 
             Groupbox:Resize()
-            if Info.Visible == false then
-                Groupbox.Visible = false
-                BoxHolder.Visible = false
-            end
             Tab.Groupboxes[Info.Name] = Groupbox
+
+            if Info.Visible == false then
+                Groupbox:Hide()
+            end
 
             return Groupbox
         end

--- a/Library.lua
+++ b/Library.lua
@@ -8889,6 +8889,10 @@ function Library:CreateWindow(WindowInfo)
                 Elements = {},
             }
 
+            function Groupbox:SetVisible(Visible)
+                self.BoxHolder.Visible = Visible
+            end
+
             function Groupbox:Resize()
                 GroupboxHolder.Size = UDim2.new(1, 0, 0, (GroupboxList.AbsoluteContentSize.Y / Library.DPIScale) + 49)
             end
@@ -8928,17 +8932,20 @@ function Library:CreateWindow(WindowInfo)
             setmetatable(Groupbox, BaseGroupbox)
 
             Groupbox:Resize()
+            if Info.Visible == false then
+                BoxHolder.Visible = false
+            end
             Tab.Groupboxes[Info.Name] = Groupbox
 
             return Groupbox
         end
 
-        function Tab:AddLeftGroupbox(Name, IconName)
-            return Tab:AddGroupbox({ Side = 1, Name = Name, IconName = IconName })
+        function Tab:AddLeftGroupbox(Name, IconName, Visible)
+            return Tab:AddGroupbox({ Side = 1, Name = Name, IconName = IconName, Visible = Visible })
         end
 
-        function Tab:AddRightGroupbox(Name, IconName)
-            return Tab:AddGroupbox({ Side = 2, Name = Name, IconName = IconName })
+        function Tab:AddRightGroupbox(Name, IconName, Visible)
+            return Tab:AddGroupbox({ Side = 2, Name = Name, IconName = IconName, Visible = Visible })
         end
 
         function Tab:AddTabbox(Info)

--- a/Library.lua
+++ b/Library.lua
@@ -732,6 +732,9 @@ local function ApplySearchToTab(Tab, Search)
 
     --// Loop through Groupboxes to get Elements Info
     for _, Groupbox in Tab.Groupboxes do
+        if Groupbox.Visible == false then
+            continue
+        end
         local VisibleElements = 0
 
         for _, ElementInfo in Groupbox.Elements do
@@ -882,7 +885,7 @@ local function ResetTab(Tab)
         end
 
         Groupbox:Resize()
-        Groupbox.BoxHolder.Visible = true
+        Groupbox.BoxHolder.Visible = Groupbox.Visible ~= false
     end
 
     for _, Tabbox in Tab.Tabboxes do
@@ -8887,9 +8890,11 @@ function Library:CreateWindow(WindowInfo)
                 Tab = Tab,
                 DependencyBoxes = {},
                 Elements = {},
+                Visible = true,
             }
 
             function Groupbox:SetVisible(Visible)
+                self.Visible = Visible
                 self.BoxHolder.Visible = Visible
             end
 
@@ -8933,6 +8938,7 @@ function Library:CreateWindow(WindowInfo)
 
             Groupbox:Resize()
             if Info.Visible == false then
+                Groupbox.Visible = false
                 BoxHolder.Visible = false
             end
             Tab.Groupboxes[Info.Name] = Groupbox


### PR DESCRIPTION
Added a `SetVisible(Visible: boolean)` method to GroupBox objects and an optional third argument to `AddLeftGroupbox`/`AddRightGroupbox` to control initial visibility at creation time.

Previously there was no supported way to hide a GroupBox at runtime or start one hidden, forcing scripts to use brittle workarounds. This allows conditional UI patterns like gamepass-gated sections to work cleanly:
```lua
local Box = Tabs.Main:AddLeftGroupbox("Premium", nil, false)
if playerOwnsGamepass(ID) then Box:SetVisible(true) end
```
`BoxHolder` is toggled (not `GroupboxHolder`) so the layout collapses properly. The `Visible` argument defaults to `true` via a strict `== false` check, preserving full backwards compatibility.