### PR TITLE
Add drag-select to Multi dropdowns

### DIFF
--- a/Library.lua
+++ b/Library.lua
@@ -6159,12 +6159,28 @@ do
             return ReturnCount == true and GetTableSize(Table) or Table
         end
 
+        local DragSelecting = false
+        local DragSelectState = false
+        local DragInputEndedConn = nil
+
+        local function StopDragSelect()
+            DragSelecting = false
+            DragSelectState = false
+            if DragInputEndedConn then
+                DragInputEndedConn:Disconnect()
+                DragInputEndedConn = nil
+            end
+        end
+
         local Buttons = {}
         function Dropdown:BuildDropdownList()
             local Values = Dropdown.Values
             local DisabledValues = Dropdown.DisabledValues
 
+            StopDragSelect()
+
             for Button, _ in Buttons do
+                if not Button.Parent then continue end
                 Button.Parent:Destroy()
             end
             table.clear(Buttons)
@@ -6256,6 +6272,8 @@ do
 
                 if not IsDisabled then
                     Button.MouseButton1Click:Connect(function()
+                        if DragSelecting then return end
+
                         local Try = not Selected
 
                         if not (Dropdown:GetActiveValues(true) == 1 and not Try and not Info.AllowNull) then
@@ -6278,6 +6296,53 @@ do
                         Library:SafeCallback(Dropdown.Callback, Dropdown.Value)
                         Library:SafeCallback(Dropdown.Changed, Dropdown.Value)
                     end)
+
+                    if Info.Multi then
+                        Button.InputBegan:Connect(function(Input)
+                            if Input.UserInputType ~= Enum.UserInputType.MouseButton1 then return end
+
+                            DragSelectState = not Selected
+                            DragSelecting = true
+
+                            local Try = DragSelectState
+                            if not (Dropdown:GetActiveValues(true) == 1 and not Try and not Info.AllowNull) then
+                                Selected = Try
+                                Dropdown.Value[Value] = Selected and true or nil
+                                for _, OtherButton in Buttons do
+                                    OtherButton:UpdateButton()
+                                end
+                            end
+                            Table:UpdateButton()
+                            Dropdown:Display()
+
+                            if DragInputEndedConn then
+                                DragInputEndedConn:Disconnect()
+                            end
+                            DragInputEndedConn = UserInputService.InputEnded:Connect(function(EndInput)
+                                if EndInput.UserInputType ~= Enum.UserInputType.MouseButton1 then return end
+                                Library:UpdateDependencyBoxes()
+                                Library:SafeCallback(Dropdown.Callback, Dropdown.Value)
+                                Library:SafeCallback(Dropdown.Changed, Dropdown.Value)
+                                StopDragSelect()
+                            end)
+                            table.insert(Dropdown.Connections, DragInputEndedConn)
+                        end)
+
+                        Button.MouseEnter:Connect(function()
+                            if not DragSelecting then return end
+
+                            local Try = DragSelectState
+                            if not (Dropdown:GetActiveValues(true) == 1 and not Try and not Info.AllowNull) then
+                                Selected = Try
+                                Dropdown.Value[Value] = Selected and true or nil
+                                for _, OtherButton in Buttons do
+                                    OtherButton:UpdateButton()
+                                end
+                            end
+                            Table:UpdateButton()
+                            Dropdown:Display()
+                        end)
+                    end
                 end
 
                 Table:UpdateButton()

--- a/Library.lua
+++ b/Library.lua
@@ -6594,7 +6594,9 @@ do
 
                     if Info.Multi then
                         Button.InputBegan:Connect(function(Input)
-                            if Input.UserInputType ~= Enum.UserInputType.MouseButton1 then return end
+                            local IsValidDragStart = Input.UserInputType == Enum.UserInputType.MouseButton1
+                            or Input.UserInputType == Enum.UserInputType.Touch
+                            if not IsValidDragStart then return end
 
                             DragSelectState = not Selected
                             DragSelecting = true
@@ -6614,7 +6616,9 @@ do
                                 DragInputEndedConn:Disconnect()
                             end
                             DragInputEndedConn = UserInputService.InputEnded:Connect(function(EndInput)
-                                if EndInput.UserInputType ~= Enum.UserInputType.MouseButton1 then return end
+                                local IsValidDragEnd = EndInput.UserInputType == Enum.UserInputType.MouseButton1
+                                or EndInput.UserInputType == Enum.UserInputType.Touch
+                                if not IsValidDragEnd then return end
                                 Library:UpdateDependencyBoxes()
                                 Library:SafeCallback(Dropdown.Callback, Dropdown.Value)
                                 Library:SafeCallback(Dropdown.Changed, Dropdown.Value)

--- a/Library.lua
+++ b/Library.lua
@@ -6884,6 +6884,8 @@ do
         function Dropdown:Destroy()
             Dropdown.Destroyed = true
 
+            StopDragSelect()
+
             if Dropdown.Connections then
                 for _, Connection in Dropdown.Connections do
                     Connection:Disconnect()

--- a/Library.lua
+++ b/Library.lua
@@ -6594,9 +6594,7 @@ do
 
                     if Info.Multi then
                         Button.InputBegan:Connect(function(Input)
-                            local IsValidDragStart = Input.UserInputType == Enum.UserInputType.MouseButton1
-                            or Input.UserInputType == Enum.UserInputType.Touch
-                            if not IsValidDragStart then return end
+                            if not IsMouseInput(Input) then return end
 
                             DragSelectState = not Selected
                             DragSelecting = true
@@ -6616,9 +6614,7 @@ do
                                 DragInputEndedConn:Disconnect()
                             end
                             DragInputEndedConn = UserInputService.InputEnded:Connect(function(EndInput)
-                                local IsValidDragEnd = EndInput.UserInputType == Enum.UserInputType.MouseButton1
-                                or EndInput.UserInputType == Enum.UserInputType.Touch
-                                if not IsValidDragEnd then return end
+                                if not IsMouseInput(EndInput) then return end
                                 Library:UpdateDependencyBoxes()
                                 Library:SafeCallback(Dropdown.Callback, Dropdown.Value)
                                 Library:SafeCallback(Dropdown.Changed, Dropdown.Value)

--- a/Library.lua
+++ b/Library.lua
@@ -483,6 +483,7 @@ local Templates = {
         ValueImages = {},
 
         Multi = false,
+        DragSelect = false,
         MaxVisibleDropdownItems = 8,
 
         Callback = function() end,
@@ -6196,6 +6197,7 @@ do
             ValueImages = Info.ValueImages,
 
             Multi = Info.Multi,
+            DragSelect = Info.Multi and Info.DragSelect or false,
 
             SpecialType = Info.SpecialType,
             ExcludeLocalPlayer = Info.ExcludeLocalPlayer,
@@ -6594,6 +6596,7 @@ do
 
                     if Info.Multi then
                         Button.InputBegan:Connect(function(Input)
+                            if not Dropdown.DragSelect then return end
                             if not IsMouseInput(Input) then return end
 
                             DragSelectState = not Selected
@@ -6766,6 +6769,14 @@ do
 
             Label.Text = Text and Text or ""
             Label.Visible = not not Text
+        end
+
+        function Dropdown:SetDragSelect(Value: boolean)
+            Dropdown.DragSelect = Info.Multi and Value or false
+
+            if not Dropdown.DragSelect then
+                StopDragSelect()
+            end
         end
 
         local ToggleDropdown = function()

--- a/Library.lua
+++ b/Library.lua
@@ -644,6 +644,10 @@ local function IsMouseClickInput(Input: InputObject)
         Input.UserInputType == Enum.UserInputType.MouseButton2 or 
         Input.UserInputType == Enum.UserInputType.MouseButton3
 end
+local function IsMovementInput(Input: InputObject)
+    return (Input.UserInputType == Enum.UserInputType.MouseMovement or Input.UserInputType == Enum.UserInputType.Touch)
+        and Library.IsRobloxFocused
+end
 
 local function GetTableSize(Table: { [any]: any })
     local Size = 0
@@ -6197,7 +6201,7 @@ do
             ValueImages = Info.ValueImages,
 
             Multi = Info.Multi,
-            DragSelect = Info.Multi and Info.DragSelect or false,
+            DragSelect = Info.Multi and not Library.IsMobile and Info.DragSelect == true,
 
             SpecialType = Info.SpecialType,
             ExcludeLocalPlayer = Info.ExcludeLocalPlayer,
@@ -6453,20 +6457,50 @@ do
             return ReturnCount == true and GetTableSize(Table) or Table
         end
 
+        local Buttons = {}
         local DragSelecting = false
-        local DragSelectState = false
+        local DragStartIndex = nil
+        local DragInitialValues = {}
         local DragInputEndedConn = nil
+        local DragInputChangedConn = nil
 
         local function StopDragSelect()
             DragSelecting = false
-            DragSelectState = false
+            DragStartIndex = nil
+            table.clear(DragInitialValues)
+
             if DragInputEndedConn then
                 DragInputEndedConn:Disconnect()
                 DragInputEndedConn = nil
             end
+
+            if DragInputChangedConn then
+                DragInputChangedConn:Disconnect()
+                DragInputChangedConn = nil
+            end
         end
 
-        local Buttons = {}
+        local function UpdateDrag(CurrentIndex)
+            local Min = math.min(DragStartIndex, CurrentIndex)
+            local Max = math.max(DragStartIndex, CurrentIndex)
+
+            for OtherButton, OtherTable in Buttons do
+                local InRange = OtherTable.Index >= Min and OtherTable.Index <= Max
+                local Try = DragInitialValues[OtherTable.Value]
+                if InRange then
+                    Try = not Try
+                end
+
+                if not (Dropdown:GetActiveValues(true) == 1 and not Try and not Info.AllowNull) then
+                    Dropdown.Value[OtherTable.Value] = Try and true or nil
+                end
+
+                OtherTable:UpdateButton()
+            end
+
+            Dropdown:Display()
+        end
+
         function Dropdown:BuildDropdownList()
             local Values = Dropdown.Values
             local DisabledValues = Dropdown.DisabledValues
@@ -6481,7 +6515,7 @@ do
                 Button.Parent:Destroy()
             end
             table.clear(Buttons)
-            
+
             local Count = 0
             local ProcessedCount = 0
             local TotalLen = GetTableSize(Values) + GetTableSize(DisabledValues)
@@ -6567,12 +6601,14 @@ do
                     end
                 end
 
+                Table.Index = Count
+                Table.Value = Value
+
                 if not IsDisabled then
                     Button.MouseButton1Click:Connect(function()
                         if DragSelecting then return end
 
                         local Try = not Selected
-
                         if not (Dropdown:GetActiveValues(true) == 1 and not Try and not Info.AllowNull) then
                             Selected = Try
                             if Info.Multi then
@@ -6594,51 +6630,51 @@ do
                         Library:SafeCallback(Dropdown.Changed, Dropdown.Value)
                     end)
 
-                    if Info.Multi then
-                        Button.InputBegan:Connect(function(Input)
-                            if not Dropdown.DragSelect then return end
-                            if not IsMouseInput(Input) then return end
+                    if Info.Multi and Dropdown.DragSelect and not Library.IsMobile then
+                        Button.InputBegan:Connect(function(StartInput)
+                            if not IsMouseInput(StartInput) then return end
 
-                            DragSelectState = not Selected
                             DragSelecting = true
+                            DragStartIndex = Table.Index
+                            table.clear(DragInitialValues)
 
-                            local Try = DragSelectState
-                            if not (Dropdown:GetActiveValues(true) == 1 and not Try and not Info.AllowNull) then
-                                Selected = Try
-                                Dropdown.Value[Value] = Selected and true or nil
-                                for _, OtherButton in Buttons do
-                                    OtherButton:UpdateButton()
+                            for OtherButton, OtherTable in Buttons do
+                                DragInitialValues[OtherTable.Value] = Dropdown.Value[OtherTable.Value]
+                            end
+
+                            UpdateDrag(Table.Index)
+
+                            if DragInputEndedConn then DragInputEndedConn:Disconnect() end
+                            if DragInputChangedConn then DragInputChangedConn:Disconnect() end
+
+                            DragInputChangedConn = Library:GiveSignal(UserInputService.InputChanged:Connect(function(ChangeInput)
+                                if not IsMovementInput(ChangeInput) and ChangeInput ~= StartInput then
+                                    return
                                 end
-                            end
-                            Table:UpdateButton()
-                            Dropdown:Display()
 
-                            if DragInputEndedConn then
-                                DragInputEndedConn:Disconnect()
-                            end
-                            DragInputEndedConn = UserInputService.InputEnded:Connect(function(EndInput)
-                                if not IsMouseInput(EndInput) then return end
+                                local Pos = ChangeInput.Position
+                                for OtherButton, OtherTable in Buttons do
+                                    if Library:MouseIsOverFrame(OtherButton, Pos) then
+                                        UpdateDrag(OtherTable.Index)
+                                        break
+                                    end
+                                end
+                            end))
+
+                            DragInputEndedConn = Library:GiveSignal(UserInputService.InputEnded:Connect(function(EndInput)
+                                if EndInput ~= StartInput and not (IsMouseInput(EndInput) and EndInput.UserInputType == StartInput.UserInputType) then
+                                    return
+                                end
+
                                 Library:UpdateDependencyBoxes()
                                 Library:SafeCallback(Dropdown.Callback, Dropdown.Value)
                                 Library:SafeCallback(Dropdown.Changed, Dropdown.Value)
+
                                 StopDragSelect()
-                            end)
+                            end))
+
                             table.insert(Dropdown.Connections, DragInputEndedConn)
-                        end)
-
-                        Button.MouseEnter:Connect(function()
-                            if not DragSelecting then return end
-
-                            local Try = DragSelectState
-                            if not (Dropdown:GetActiveValues(true) == 1 and not Try and not Info.AllowNull) then
-                                Selected = Try
-                                Dropdown.Value[Value] = Selected and true or nil
-                                for _, OtherButton in Buttons do
-                                    OtherButton:UpdateButton()
-                                end
-                            end
-                            Table:UpdateButton()
-                            Dropdown:Display()
+                            table.insert(Dropdown.Connections, DragInputChangedConn)
                         end)
                     end
                 end
@@ -6772,11 +6808,12 @@ do
         end
 
         function Dropdown:SetDragSelect(Value: boolean)
-            Dropdown.DragSelect = Info.Multi and Value or false
-
-            if not Dropdown.DragSelect then
-                StopDragSelect()
+            if not Info.Multi or Library.IsMobile then 
+                Value = false
             end
+
+            Dropdown.DragSelect = Value == true
+            Dropdown:BuildDropdownList()
         end
 
         local ToggleDropdown = function()


### PR DESCRIPTION
Selecting many values in a long Multi dropdown (e.g. a player list) required clicking each item individually. Holding left click and dragging over items now selects or deselects them in one gesture.

Three upvalues (`DragSelecting`, `DragSelectState`, `DragInputEndedConn`) and a `StopDragSelect` helper are declared outside `BuildDropdownList` so they survive list rebuilds. `BuildDropdownList` calls `StopDragSelect` at the top to cancel any in-progress drag before destroying and recreating buttons.

For each non-disabled item in a Multi dropdown:

- `InputBegan` (MB1) starts the drag, locks the toggle direction to the opposite of the pressed item's current state, applies it immediately, and attaches a `UserInputService.InputEnded` listener that fires callbacks once and clears drag state on mouse release.

- `MouseEnter` extends the drag to each item the cursor passes over, applying the locked direction and respecting `AllowNull`.

- `MouseButton1Click` returns early when `DragSelecting` is true to suppress the synthetic click Roblox fires after `InputEnded`, preventing the first item from being double-toggled.

Callbacks fire once at the end of the gesture rather than per item to avoid hammering `Callback`/`Changed` during a fast drag. Single-select dropdowns are unaffected.
<img width="244" height="286" alt="ezgif-83fcfe3be54a0562" src="https://github.com/user-attachments/assets/b206d5a1-22ac-4936-84ee-e7e0fbfe6b39" />