### PR TITLE
Save GroupBox collapsed state

### DIFF
--- a/addons/SaveManager.lua
+++ b/addons/SaveManager.lua
@@ -110,6 +110,23 @@ local SaveManager = {} do
                 end
             end,
         },
+        GroupBox = {
+            Save = function(idx, object)
+                return { type = "GroupBox", idx = idx, collapsed = object.Collapsed }
+            end,
+            Load = function(idx, data)
+                if type(data.collapsed) ~= "boolean" then return end
+                for _, Tab in pairs(SaveManager.Library.Tabs) do
+                    if Tab.Groupboxes then
+                        local groupbox = Tab.Groupboxes[idx]
+                        if groupbox and groupbox.Collapsed ~= data.collapsed then
+                            groupbox:SetCollapsed(data.collapsed)
+                            return
+                        end
+                    end
+                end
+            end,
+        },
     }
 
     function SaveManager:SetLibrary(library)
@@ -233,6 +250,14 @@ local SaveManager = {} do
             if self.Ignore[idx] then continue end
 
             table.insert(data.objects, self.Parser[option.Type].Save(idx, option))
+        end
+
+        for _, Tab in pairs(self.Library.Tabs) do
+            if not Tab.Groupboxes then continue end
+            for name, groupbox in pairs(Tab.Groupboxes) do
+                if self.Ignore[name] then continue end
+                table.insert(data.objects, self.Parser.GroupBox.Save(name, groupbox))
+            end
         end
 
         local success, encoded = pcall(HttpService.JSONEncode, HttpService, data)


### PR DESCRIPTION
Configs did not preserve which GroupBoxes the user had collapsed — they always reopened fully expanded on load, forcing the user to re-collapse them every session.

### `SaveManager.lua`

- Added a `GroupBox` parser with `Save`/`Load` handlers.
- `Save` iterates `Library.Tabs` and records each groupbox's name and `Collapsed` boolean into `data.objects`.
- `Load` looks up the groupbox by name across all tabs and calls `SetCollapsed`, which handles the arrow rotation and resize correctly.
- Groupbox visibility (`Visible`) is intentionally not saved — it is controlled by script logic, not user interaction, so persisting it could permanently hide groupboxes with no recovery path.