### PR TITLE
Animation framework + Linoria-based window open/close animations

### DIFF
--- a/Library.lua
+++ b/Library.lua
@@ -195,6 +195,9 @@ local Library = {
     TweenInfo = TweenInfo.new(0.1, Enum.EasingStyle.Quad, Enum.EasingDirection.Out),
     NotifyTweenInfo = TweenInfo.new(0.25, Enum.EasingStyle.Quad, Enum.EasingDirection.Out),
 
+    Animations = false,
+    WindowAnimationInfo = TweenInfo.new(0.35, Enum.EasingStyle.Quad, Enum.EasingDirection.Out),
+
     Toggled = false,
     Unloaded = false,
 
@@ -332,7 +335,9 @@ local Templates = {
 
         Font = Enum.Font.Code,
         ToggleKeybind = Enum.KeyCode.RightControl,
-        
+
+        Animations = false,
+
         ShowMobileButtons = true,
         MobileButtonsSide = "Left",
 
@@ -7943,6 +7948,7 @@ function Library:CreateWindow(WindowInfo)
     Library.Scheme.Font = WindowInfo.Font
     Library.ToggleKeybind = WindowInfo.ToggleKeybind
     Library.GlobalSearch = WindowInfo.GlobalSearch
+    Library.Animations = WindowInfo.Animations
 
     local IsDefaultSearchbarSize = WindowInfo.SearchbarSize == UDim2.fromScale(1, 1)
     local MainFrame
@@ -8326,6 +8332,8 @@ function Library:CreateWindow(WindowInfo)
 
     --// Window Table \\--
     local Window = {}
+    local Fading = false
+    local TransparencyCache = {}
 
     local function SetUICorner(UICorner, Corner, HalfCurrent, HalfValue, Value)
         local Current = UICorner[Corner]
@@ -10283,6 +10291,10 @@ function Library:CreateWindow(WindowInfo)
     end
 
     function Window:Toggle(Value: boolean?)
+        if Fading then
+            return
+        end
+
         if Library.ActiveLoading then
             if Value == true then
                 return
@@ -10299,7 +10311,61 @@ function Library:CreateWindow(WindowInfo)
             Library.Toggled = not Library.Toggled
         end
 
-        MainFrame.Visible = Library.Toggled
+        if Library.Animations then
+            local FadeTime = Library.WindowAnimationInfo.Time
+            Fading = true
+
+            if Library.Toggled then
+                MainFrame.Visible = true
+            end
+
+            local function FadeInstance(Desc, Properties)
+                local Cache = TransparencyCache[Desc]
+                if not Cache then
+                    Cache = {}
+                    TransparencyCache[Desc] = Cache
+                end
+
+                for _, Prop in Properties do
+                    if not Library.Toggled then
+                        Cache[Prop] = Desc[Prop]
+                    end
+
+                    if Cache[Prop] ~= nil and Cache[Prop] ~= 1 then
+                        TweenService:Create(Desc, Library.WindowAnimationInfo, {
+                            [Prop] = Library.Toggled and Cache[Prop] or 1,
+                        }):Play()
+                    end
+                end
+            end
+
+            FadeInstance(MainFrame, { "BackgroundTransparency" })
+
+            for _, Desc in MainFrame:GetDescendants() do
+                local Properties = {}
+
+                if Desc:IsA("GuiObject") then
+                    table.insert(Properties, "BackgroundTransparency")
+                end
+
+                if Desc:IsA("ImageLabel") or Desc:IsA("ImageButton") then
+                    table.insert(Properties, "ImageTransparency")
+                elseif Desc:IsA("TextLabel") or Desc:IsA("TextBox") or Desc:IsA("TextButton") then
+                    table.insert(Properties, "TextTransparency")
+                elseif Desc:IsA("UIStroke") then
+                    table.insert(Properties, "Transparency")
+                end
+
+                FadeInstance(Desc, Properties)
+            end
+
+            task.delay(FadeTime, function()
+                MainFrame.Visible = Library.Toggled
+                Fading = false
+            end)
+        else
+            MainFrame.Visible = Library.Toggled
+        end
 
         if WindowInfo.UnlockMouseWhileOpen then
             ModalElement.Modal = Library.Toggled


### PR DESCRIPTION
# Animation Framework

Adds `Library.Animations` (default `false`), a single global toggle gating all UI animation in Obsidian, set via `CreateWindow({ Animations = true })`. This is meant to be the on/off switch for every animation added going forward, not just one feature — each future animation checks `Library.Animations` before tweening and falls back to the current instant behavior when it's off, so there's one flag for the user instead of one per animation. This PR only adds the window open/close fade. At a later date, more animations will be added in a different PR, including:
- **Tab Switch:** Fade In/Wipe
- **Dropdown:** Down/Up Animation
- Groupbox Resized
- Element Hidden/Revealed or Interface/Layout Modified
- Notifications Layout Reorganized/Modified, etc.

# Window Open/Close

When `Library.Animations` is enabled, toggling the window cross-fades every visible element instead of snapping `Visible` instantly — same technique as Linoria's toggle fade (per-descendant transparency tween, with a cached value to restore to on open).

**Why a per-descendant cache instead of a flat tween:** `BackgroundTransparency`/`TextTransparency` already vary per element (selected tab/`TabButton.BackgroundTransparency` tween, slider fill, hover state), so fade-in can't target a flat `0` — it has to restore each element's actual prior value.

**Why the cache refreshes on every close, not just once:** dynamic elements like the selected tab (`TabButton.BackgroundTransparency` tween) change after the first capture. Caching once and reusing forever could restore stale state on reopen — wrong tab shown as "selected," or the active tab's highlight failing to fade because the cache thought it was already transparent. Fixed by re-capturing the live value every close.

**Why backgrounds needed handling on `TextButton`/`ImageButton` too:** buttons, sliders, and tabs are built on `TextButton` bases with real `BackgroundColor3` fills, not just text containers — treating "has background" and "is text/image" as mutually exclusive silently skipped fading their backgrounds.
<img width="800" height="661" alt="Window Open   Close" src="https://github.com/user-attachments/assets/116bc93a-fbde-40d6-9be3-986fc039ab9d" />