### PR TITLE
Dropdown List: Down/Up Animation

### DIFF
--- a/Library.lua
+++ b/Library.lua
@@ -195,6 +195,18 @@ local Library = {
     TweenInfo = TweenInfo.new(0.1, Enum.EasingStyle.Quad, Enum.EasingDirection.Out),
     NotifyTweenInfo = TweenInfo.new(0.25, Enum.EasingStyle.Quad, Enum.EasingDirection.Out),
 
+    Animations = {
+        ToggleWindow = false,
+        TabSwitch = false,
+        Dropdown = false,
+    },
+    WindowAnimationInfo = TweenInfo.new(0.35, Enum.EasingStyle.Quad, Enum.EasingDirection.Out),
+
+    TabTransitionInfo = TweenInfo.new(0.22, Enum.EasingStyle.Quad, Enum.EasingDirection.Out),
+    TabWipeOffset = 26,
+
+    DropdownTransitionInfo = TweenInfo.new(0.18, Enum.EasingStyle.Quad, Enum.EasingDirection.Out),
+
     Toggled = false,
     Unloaded = false,
 
@@ -332,7 +344,14 @@ local Templates = {
 
         Font = Enum.Font.Code,
         ToggleKeybind = Enum.KeyCode.RightControl,
-        
+
+        Animations = {
+            ToggleWindow = false,
+            TabSwitch = false,
+        },
+        TabTransitionTime = 0.22,
+        TabWipeOffset = 26,
+
         ShowMobileButtons = true,
         MobileButtonsSide = "Left",
 
@@ -1717,6 +1736,98 @@ function Library:AddBlank(Frame: GuiObject, Size: UDim2)
     })
 end
 
+local ActiveTabWipeTweens = setmetatable({}, { __mode = "k" })
+local SleeveBaseZIndex = setmetatable({}, { __mode = "k" })
+
+function Library:WrapTabSleeve(TabContainer: GuiObject, Parent: GuiObject)
+    local Sleeve = New("CanvasGroup", {
+        BackgroundTransparency = 1,
+        ClipsDescendants = true,
+        GroupTransparency = 0,
+        Size = UDim2.fromScale(1, 1),
+        Visible = false,
+        Parent = Parent,
+    })
+
+    TabContainer.Parent = Sleeve
+    TabContainer.Position = UDim2.fromScale(0, 0)
+    TabContainer.Size = UDim2.fromScale(1, 1)
+
+    SleeveBaseZIndex[Sleeve] = Sleeve.ZIndex
+
+    return Sleeve
+end
+
+function Library:PlayTabWipe(Sleeve: GuiObject, Showing: boolean, OnComplete: (() -> ())?)
+    if not Sleeve then
+        if OnComplete then
+            OnComplete()
+        end
+        return
+    end
+
+    local Existing = ActiveTabWipeTweens[Sleeve]
+    if Existing then
+        Existing:Cancel()
+        ActiveTabWipeTweens[Sleeve] = nil
+    end
+
+    local BaseZIndex = SleeveBaseZIndex[Sleeve] or Sleeve.ZIndex
+
+    if not (Library.Animations and Library.Animations.TabSwitch) then
+        Sleeve.Visible = Showing
+        Sleeve.GroupTransparency = Showing and 0 or 1
+        Sleeve.Position = UDim2.fromScale(0, 0)
+        Sleeve.ZIndex = BaseZIndex
+        if OnComplete then
+            OnComplete()
+        end
+        return
+    end
+
+    local Info = Library.TabTransitionInfo or TweenInfo.new(0.22, Enum.EasingStyle.Quad, Enum.EasingDirection.Out)
+    local Offset = Library.TabWipeOffset or 26
+
+    if Showing then
+        Sleeve.ZIndex = BaseZIndex + 1
+        Sleeve.GroupTransparency = 1
+        Sleeve.Position = UDim2.fromOffset(Offset, 0)
+        Sleeve.Visible = true
+
+        local Tween = TweenService:Create(Sleeve, Info, {
+            GroupTransparency = 0,
+            Position = UDim2.fromScale(0, 0),
+        })
+        ActiveTabWipeTweens[Sleeve] = Tween
+        Tween:Play()
+
+        local Connection
+        Connection = Tween.Completed:Connect(function(PlaybackState)
+            if Connection then
+                Connection:Disconnect()
+            end
+            if ActiveTabWipeTweens[Sleeve] == Tween then
+                ActiveTabWipeTweens[Sleeve] = nil
+            end
+            if PlaybackState == Enum.PlaybackState.Cancelled then
+                return
+            end
+            Sleeve.ZIndex = BaseZIndex
+            if OnComplete then
+                OnComplete()
+            end
+        end)
+    else
+        Sleeve.GroupTransparency = 1
+        Sleeve.Visible = false
+        Sleeve.Position = UDim2.fromScale(0, 0)
+        Sleeve.ZIndex = BaseZIndex
+        if OnComplete then
+            OnComplete()
+        end
+    end
+end
+
 --// Deprecated \\--
 function Library:MakeOutline(Frame: GuiObject, Corner: number?, ZIndex: number?)
     warn("Obsidian:MakeOutline is deprecated, please use Obsidian:AddOutline instead.")
@@ -2230,7 +2341,8 @@ function Library:AddContextMenu(
     List: number?,
     ActiveCallback: (Active: boolean) -> ()?,
     IgnoreCornerRadius: boolean?,
-    SpecificCornersOnly: ("top" | "bottom" | "no_left" | "no_top_left")? -- stupid way of doing this
+    SpecificCornersOnly: ("top" | "bottom" | "no_left" | "no_top_left")?, -- stupid way of doing this
+    Animated: boolean?
 )
     local Menu
     local ParentGui = Holder:FindFirstAncestorOfClass("ScreenGui")
@@ -2328,6 +2440,9 @@ function Library:AddContextMenu(
         Signal = nil,
 
         Size = Size,
+
+        Animated = Animated == true,
+        OpenCloseTween = nil,
     }
 
     if List then
@@ -2357,12 +2472,43 @@ function Library:AddContextMenu(
                 math.floor(Holder.AbsolutePosition.Y + Offset[2])
             )
         end
-        Menu.Size = typeof(Table.Size) == "function" and Table.Size() or Table.Size
+
+        local TargetSize = typeof(Table.Size) == "function" and Table.Size() or Table.Size
+
         if typeof(ActiveCallback) == "function" then
             Library:SafeCallback(ActiveCallback, true)
         end
 
-        Menu.Visible = true
+        if Table.OpenCloseTween then
+            Table.OpenCloseTween:Cancel()
+            Table.OpenCloseTween = nil
+        end
+
+        if Table.Animated and Library.Animations and Library.Animations.Dropdown then
+            Menu.Size = UDim2.new(TargetSize.X.Scale, TargetSize.X.Offset, 0, 0)
+            Menu.Visible = true
+
+            local Info = Library.DropdownTransitionInfo
+                or TweenInfo.new(0.18, Enum.EasingStyle.Quad, Enum.EasingDirection.Out)
+
+            local Tween = TweenService:Create(Menu, Info, { Size = TargetSize })
+            Table.OpenCloseTween = Tween
+
+            local Connection
+            Connection = Tween.Completed:Connect(function()
+                if Connection then
+                    Connection:Disconnect()
+                end
+                if Table.OpenCloseTween == Tween then
+                    Table.OpenCloseTween = nil
+                end
+            end)
+
+            Tween:Play()
+        else
+            Menu.Size = TargetSize
+            Menu.Visible = true
+        end
 
         Table.Signal = Holder:GetPropertyChangedSignal("AbsolutePosition"):Connect(function()
             if typeof(Offset) == "function" then
@@ -2387,7 +2533,6 @@ function Library:AddContextMenu(
         if CurrentMenu ~= Table then
             return
         end
-        Menu.Visible = false
 
         if Table.Signal then
             Table.Signal:Disconnect()
@@ -2397,6 +2542,37 @@ function Library:AddContextMenu(
         CurrentMenu = nil
         if typeof(ActiveCallback) == "function" then
             Library:SafeCallback(ActiveCallback, false)
+        end
+
+        if Table.OpenCloseTween then
+            Table.OpenCloseTween:Cancel()
+            Table.OpenCloseTween = nil
+        end
+
+        if Table.Animated and Library.Animations and Library.Animations.Dropdown then
+            local CurrentSize = Menu.Size
+            local CollapsedSize = UDim2.new(CurrentSize.X.Scale, CurrentSize.X.Offset, 0, 0)
+
+            local Info = Library.DropdownTransitionInfo
+                or TweenInfo.new(0.18, Enum.EasingStyle.Quad, Enum.EasingDirection.Out)
+
+            local Tween = TweenService:Create(Menu, Info, { Size = CollapsedSize })
+            Table.OpenCloseTween = Tween
+
+            local Connection
+            Connection = Tween.Completed:Connect(function(PlaybackState)
+                if Connection then
+                    Connection:Disconnect()
+                end
+                if Table.OpenCloseTween == Tween then
+                    Table.OpenCloseTween = nil
+                end
+                Menu.Visible = false
+            end)
+
+            Tween:Play()
+        else
+            Menu.Visible = false
         end
     end
 
@@ -2424,6 +2600,11 @@ function Library:AddContextMenu(
 
         if CurrentMenu == Table then
             Table:Close()
+        end
+
+        if Table.OpenCloseTween then
+            Table.OpenCloseTween:Cancel()
+            Table.OpenCloseTween = nil
         end
 
         if Menu then
@@ -6102,7 +6283,8 @@ do
                 DropdownCorner.BottomLeftRadius = Active and UDim.new(0, 0) or UDim.new(0, Library.CornerRadius / 2)
             end,
             false,
-            "bottom"
+            "bottom",
+            true
         )
         Dropdown.Menu = MenuTable
 
@@ -7911,6 +8093,23 @@ function Library:Notify(...)
 end
 
 function Library:CreateWindow(WindowInfo)
+    --// Old Naming (pre-Validate) \\--
+    if typeof(WindowInfo) == "table" then
+        if typeof(WindowInfo.Animations) == "boolean" then
+            local ToggleWindow = WindowInfo.Animations
+            WindowInfo.Animations = {
+                ToggleWindow = ToggleWindow,
+                TabSwitch = ToggleWindow,
+            }
+        end
+        if typeof(WindowInfo.TabSwitch) == "boolean" and typeof(WindowInfo.Animations) ~= "table" then
+            WindowInfo.Animations = {}
+        end
+        if typeof(WindowInfo.TabSwitch) == "boolean" and typeof(WindowInfo.Animations) == "table" and WindowInfo.Animations.TabSwitch == nil then
+            WindowInfo.Animations.TabSwitch = WindowInfo.TabSwitch
+        end
+    end
+
     WindowInfo = Library:Validate(WindowInfo, Templates.Window)
     local ViewportSize: Vector2 = workspace.CurrentCamera.ViewportSize
     if RunService:IsStudio() and ViewportSize.X <= 5 and ViewportSize.Y <= 5 then
@@ -7954,6 +8153,14 @@ function Library:CreateWindow(WindowInfo)
     Library.Scheme.Font = WindowInfo.Font
     Library.ToggleKeybind = WindowInfo.ToggleKeybind
     Library.GlobalSearch = WindowInfo.GlobalSearch
+    Library.Animations = WindowInfo.Animations
+
+    Library.TabTransitionInfo = TweenInfo.new(
+        math.max(0, WindowInfo.TabTransitionTime or 0.22),
+        Enum.EasingStyle.Quad,
+        Enum.EasingDirection.Out
+    )
+    Library.TabWipeOffset = WindowInfo.TabWipeOffset or 26
 
     local IsDefaultSearchbarSize = WindowInfo.SearchbarSize == UDim2.fromScale(1, 1)
     local MainFrame
@@ -8319,6 +8526,7 @@ function Library:CreateWindow(WindowInfo)
             BackgroundColor3 = function()
                 return Library:GetBetterColor(Library.Scheme.BackgroundColor, 1)
             end,
+            ClipsDescendants = true,
             Name = "Container",
             Position = UDim2.new(1, 0, 0, 49),
             Size = UDim2.new(1, -InitialLeftWidth - 1, 1, -70),
@@ -8337,13 +8545,11 @@ function Library:CreateWindow(WindowInfo)
 
     --// Window Table \\--
     local Window = {}
+    local Fading = false
+    local TransparencyCache = {}
 
     local function SetUICorner(UICorner, Corner, HalfCurrent, HalfValue, Value)
         local Current = UICorner[Corner]
-        if Current.Offset == 0 and Current.Scale == 0 then
-            return
-        end
-
         UICorner[Corner] = Current.Offset == HalfCurrent and HalfValue or Value
     end
 
@@ -8511,6 +8717,7 @@ function Library:CreateWindow(WindowInfo)
         local TabIcon
 
         local TabContainer
+        local TabSleeve
         local TabLeft
         local TabRight
 
@@ -8567,7 +8774,7 @@ function Library:CreateWindow(WindowInfo)
             TabContainer = New("Frame", {
                 BackgroundTransparency = 1,
                 Size = UDim2.fromScale(1, 1),
-                Visible = false,
+                Visible = true,
                 Parent = Container,
             })
 
@@ -8639,6 +8846,8 @@ function Library:CreateWindow(WindowInfo)
                 })
             end
         end
+
+        TabSleeve = Library:WrapTabSleeve(TabContainer, Container)
 
         --// Warning Box \\--
         local WarningBoxHolder = New("Frame", {
@@ -9418,6 +9627,10 @@ function Library:CreateWindow(WindowInfo)
         end
 
         function Tab:Show()
+            if Library.ActiveTab == Tab then
+                return
+            end
+
             if Library.ActiveTab then
                 Library.ActiveTab:Hide()
             end
@@ -9438,7 +9651,7 @@ function Library:CreateWindow(WindowInfo)
                 Window:ShowTabInfo(Name, Description)
             end
 
-            TabContainer.Visible = true
+            Library:PlayTabWipe(TabSleeve, true)
             Tab:RefreshSides()
 
             Library.ActiveTab = Tab
@@ -9460,7 +9673,7 @@ function Library:CreateWindow(WindowInfo)
                     ImageTransparency = 0.5,
                 }):Play()
             end
-            TabContainer.Visible = false
+            Library:PlayTabWipe(TabSleeve, false)
 
             Window:HideTabInfo()
 
@@ -9504,7 +9717,9 @@ function Library:CreateWindow(WindowInfo)
                 end
             end
 
-            if TabContainer then
+            if TabSleeve then
+                TabSleeve:Destroy()
+            elseif TabContainer then
                 TabContainer:Destroy()
             end
 
@@ -9563,6 +9778,7 @@ function Library:CreateWindow(WindowInfo)
         local TabIcon
 
         local TabContainer
+        local TabSleeve
 
         Icon = if Icon == "key" then KeyIcon else Library:GetCustomIcon(Icon)
         do
@@ -9619,7 +9835,7 @@ function Library:CreateWindow(WindowInfo)
                 CanvasSize = UDim2.fromScale(0, 0),
                 ScrollBarThickness = 0,
                 Size = UDim2.fromScale(1, 1),
-                Visible = false,
+                Visible = true,
                 Parent = Container,
             })
             New("UIListLayout", {
@@ -9634,6 +9850,8 @@ function Library:CreateWindow(WindowInfo)
                 Parent = TabContainer,
             })
         end
+
+        TabSleeve = Library:WrapTabSleeve(TabContainer, Container)
 
         --// Tab Table \\--
         local Tab = {
@@ -9712,7 +9930,9 @@ function Library:CreateWindow(WindowInfo)
         end
         
         function Tab:Destroy()
-            if TabContainer then
+            if TabSleeve then
+                TabSleeve:Destroy()
+            elseif TabContainer then
                 TabContainer:Destroy()
             end
 
@@ -9750,6 +9970,10 @@ function Library:CreateWindow(WindowInfo)
         end
 
         function Tab:Show()
+            if Library.ActiveTab == Tab then
+                return
+            end
+
             if Library.ActiveTab then
                 Library.ActiveTab:Hide()
             end
@@ -9765,7 +9989,7 @@ function Library:CreateWindow(WindowInfo)
                     ImageTransparency = 0,
                 }):Play()
             end
-            TabContainer.Visible = true
+            Library:PlayTabWipe(TabSleeve, true)
 
             if Description then
                 Window:ShowTabInfo(Name, Description)
@@ -9792,7 +10016,7 @@ function Library:CreateWindow(WindowInfo)
                     ImageTransparency = 0.5,
                 }):Play()
             end
-            TabContainer.Visible = false
+            Library:PlayTabWipe(TabSleeve, false)
 
             Window:HideTabInfo()
 
@@ -10314,6 +10538,10 @@ function Library:CreateWindow(WindowInfo)
     end
 
     function Window:Toggle(Value: boolean?)
+        if Fading then
+            return
+        end
+
         if Library.ActiveLoading then
             if Value == true then
                 return
@@ -10330,7 +10558,61 @@ function Library:CreateWindow(WindowInfo)
             Library.Toggled = not Library.Toggled
         end
 
-        MainFrame.Visible = Library.Toggled
+        if Library.Animations and Library.Animations.ToggleWindow then
+            local FadeTime = Library.WindowAnimationInfo.Time
+            Fading = true
+
+            if Library.Toggled then
+                MainFrame.Visible = true
+            end
+
+            local function FadeInstance(Desc, Properties)
+                local Cache = TransparencyCache[Desc]
+                if not Cache then
+                    Cache = {}
+                    TransparencyCache[Desc] = Cache
+                end
+
+                for _, Prop in Properties do
+                    if not Library.Toggled then
+                        Cache[Prop] = Desc[Prop]
+                    end
+
+                    if Cache[Prop] ~= nil and Cache[Prop] ~= 1 then
+                        TweenService:Create(Desc, Library.WindowAnimationInfo, {
+                            [Prop] = Library.Toggled and Cache[Prop] or 1,
+                        }):Play()
+                    end
+                end
+            end
+
+            FadeInstance(MainFrame, { "BackgroundTransparency" })
+
+            for _, Desc in MainFrame:GetDescendants() do
+                local Properties = {}
+
+                if Desc:IsA("GuiObject") then
+                    table.insert(Properties, "BackgroundTransparency")
+                end
+
+                if Desc:IsA("ImageLabel") or Desc:IsA("ImageButton") then
+                    table.insert(Properties, "ImageTransparency")
+                elseif Desc:IsA("TextLabel") or Desc:IsA("TextBox") or Desc:IsA("TextButton") then
+                    table.insert(Properties, "TextTransparency")
+                elseif Desc:IsA("UIStroke") then
+                    table.insert(Properties, "Transparency")
+                end
+
+                FadeInstance(Desc, Properties)
+            end
+
+            task.delay(FadeTime, function()
+                MainFrame.Visible = Library.Toggled
+                Fading = false
+            end)
+        else
+            MainFrame.Visible = Library.Toggled
+        end
 
         if WindowInfo.UnlockMouseWhileOpen then
             ModalElement.Modal = Library.Toggled

--- a/Library.lua
+++ b/Library.lua
@@ -161,69 +161,90 @@ end
 
 local Library = {
     LocalPlayer = LocalPlayer,
-    DevicePlatform = nil,
-    IsMobile = false,
     IsRobloxFocused = true,
 
+    --// Device \\--
+    DevicePlatform = nil,
+    IsMobile = false,
+
+    --// Obsidian Windows \\--
     ScreenGui = nil,
     Window = nil,
     WindowContainer = nil,
 
+    --// Search \\--
     SearchText = "",
     Searching = false,
     GlobalSearch = false,
     LastSearchTab = nil,
 
+    --// Tabs \\--
     ActiveTab = nil,
     Tabs = {},
     TabButtons = {},
+
+    --// Dependency Boxes \\--
     DependencyBoxes = {},
 
+    --// Keybinds Frame \\--
     KeybindFrame = nil,
     KeybindContainer = nil,
     KeybindToggles = {},
 
+    --// Notifications \\--
     Notifications = {},
+    NotifySide = "Right",
+    NotifyTweenInfo = TweenInfo.new(0.25, Enum.EasingStyle.Quad, Enum.EasingDirection.Out),
+
+    --// Dialogues \\--
     Dialogues = {},
-    ActiveLoading = nil,
     ActiveDialog = nil,
 
+    --// Loading Window \\--
+    ActiveLoading = nil,
+
+    --// Corners \\--
     Corners = {},
     SpecificCorners = {},
 
-    ToggleKeybind = Enum.KeyCode.RightControl,
+    --// Animations \\--
     TweenInfo = TweenInfo.new(0.1, Enum.EasingStyle.Quad, Enum.EasingDirection.Out),
-    NotifyTweenInfo = TweenInfo.new(0.25, Enum.EasingStyle.Quad, Enum.EasingDirection.Out),
+
+    TabTransitionInfo = TweenInfo.new(0.22, Enum.EasingStyle.Quad, Enum.EasingDirection.Out),
+    TabSwipeOffset = 26,
+    TabSwipeFrom = "bottom",
+
+    WindowAnimationInfo = TweenInfo.new(0.35, Enum.EasingStyle.Quad, Enum.EasingDirection.Out),
+    DropdownTransitionInfo = TweenInfo.new(0.18, Enum.EasingStyle.Quad, Enum.EasingDirection.Out),
 
     Animations = {
         ToggleWindow = false,
         TabSwitch = false,
-        Dropdown = false,
+        Dropdown = false
     },
-    WindowAnimationInfo = TweenInfo.new(0.35, Enum.EasingStyle.Quad, Enum.EasingDirection.Out),
 
-    TabTransitionInfo = TweenInfo.new(0.22, Enum.EasingStyle.Quad, Enum.EasingDirection.Out),
-    TabWipeOffset = 26,
-
-    DropdownTransitionInfo = TweenInfo.new(0.18, Enum.EasingStyle.Quad, Enum.EasingDirection.Out),
-
+    --// States \\--
     Toggled = false,
     Unloaded = false,
 
+    --// Elements \\--
     Labels = Labels,
     Buttons = Buttons,
     Toggles = Toggles,
     Options = Options,
 
-    NotifySide = "Right",
+    --// Options \\--
+    ToggleKeybind = Enum.KeyCode.RightControl,
+    ShowToggleFrameInKeybinds = true,
+
+    NotifyOnError = false,
     ShowCustomCursor = true,
     ForceCheckbox = false,
-    ShowToggleFrameInKeybinds = true,
-    NotifyOnError = false,
 
     CantDragForced = false,
     DraggableElements = {},
 
+    --// Signals \\--
     Signals = {},
     UnloadSignals = {},
 
@@ -232,6 +253,7 @@ local Library = {
     DPIScale = 1,
     CornerRadius = 4,
 
+    --// Scheme \\--
     IsLightTheme = false,
     Scheme = {
         BackgroundColor = Color3.fromRGB(15, 15, 15),
@@ -249,14 +271,16 @@ local Library = {
         BackgroundImage = ""
     },
 
+    --// Registry \\--
     Registry = {},
 	Scales = {},
 	ScalesOffset = {},
 
+    --// Misc \\--
     ImageManager = CustomImageManager,
     ShowCursorBinding = string.sub(tostring({}), 10),
 
-    Notify = nil -- we love luau lsp
+    Notify = nil, Toggle = nil -- we love luau lsp
 }
 
 if RunService:IsStudio() then
@@ -277,7 +301,7 @@ else
 end
 
 local Templates = {
-    --// UI \\-
+    --// UI \\--
     Frame = {
         BorderSizePixel = 0,
     },
@@ -345,13 +369,6 @@ local Templates = {
         Font = Enum.Font.Code,
         ToggleKeybind = Enum.KeyCode.RightControl,
 
-        Animations = {
-            ToggleWindow = false,
-            TabSwitch = false,
-        },
-        TabTransitionTime = 0.22,
-        TabWipeOffset = 26,
-
         ShowMobileButtons = true,
         MobileButtonsSide = "Left",
 
@@ -372,7 +389,18 @@ local Templates = {
         CompactWidthActivation = 128,
 
         --// Background \\--
-        BackgroundImage = ""
+        BackgroundImage = "",
+
+        --// Animations \\--
+        Animations = {
+            ToggleWindow = false,
+            TabSwitch = false,
+            Dropdown = false
+        },
+
+        TabTransitionTime = 0.22,
+        TabSwipeOffset = 26,
+        TabSwipeFrom = "bottom"
     },
     Dialog = {
         Title = "Dialog",
@@ -1736,92 +1764,92 @@ function Library:AddBlank(Frame: GuiObject, Size: UDim2)
     })
 end
 
-local ActiveTabWipeTweens = setmetatable({}, { __mode = "k" })
-local SleeveBaseZIndex = setmetatable({}, { __mode = "k" })
+--// Animations \\--
+local TransparencyCache = {}
+local ActiveTabTweens = setmetatable({}, { __mode = "k" })
 
-function Library:WrapTabSleeve(TabContainer: GuiObject, Parent: GuiObject)
-    local Sleeve = New("CanvasGroup", {
-        BackgroundTransparency = 1,
-        ClipsDescendants = true,
-        GroupTransparency = 0,
-        Size = UDim2.fromScale(1, 1),
-        Visible = false,
-        Parent = Parent,
-    })
-
-    TabContainer.Parent = Sleeve
-    TabContainer.Position = UDim2.fromScale(0, 0)
-    TabContainer.Size = UDim2.fromScale(1, 1)
-
-    SleeveBaseZIndex[Sleeve] = Sleeve.ZIndex
-
-    return Sleeve
-end
-
-function Library:PlayTabWipe(Sleeve: GuiObject, Showing: boolean, OnComplete: (() -> ())?)
-    if not Sleeve then
+function Library:PlayTabAnimation(TabCanvas: CanvasGroup, Showing: boolean, OnComplete: (() -> ())?)
+    if not TabCanvas then
         if OnComplete then
             OnComplete()
         end
+
         return
     end
 
-    local Existing = ActiveTabWipeTweens[Sleeve]
+    local Existing = ActiveTabTweens[TabCanvas]
     if Existing then
         Existing:Cancel()
-        ActiveTabWipeTweens[Sleeve] = nil
+        ActiveTabTweens[TabCanvas] = nil
     end
 
-    local BaseZIndex = SleeveBaseZIndex[Sleeve] or Sleeve.ZIndex
-
+    local BaseZIndex = TabCanvas.ZIndex
     if not (Library.Animations and Library.Animations.TabSwitch) then
-        Sleeve.Visible = Showing
-        Sleeve.GroupTransparency = Showing and 0 or 1
-        Sleeve.Position = UDim2.fromScale(0, 0)
-        Sleeve.ZIndex = BaseZIndex
+        TabCanvas.Visible = Showing
+        TabCanvas.GroupTransparency = Showing and 0 or 1
+        TabCanvas.Position = UDim2.fromScale(0, 0)
+        TabCanvas.ZIndex = BaseZIndex
+
         if OnComplete then
             OnComplete()
         end
+
         return
     end
 
-    local Info = Library.TabTransitionInfo or TweenInfo.new(0.22, Enum.EasingStyle.Quad, Enum.EasingDirection.Out)
-    local Offset = Library.TabWipeOffset or 26
-
     if Showing then
-        Sleeve.ZIndex = BaseZIndex + 1
-        Sleeve.GroupTransparency = 1
-        Sleeve.Position = UDim2.fromOffset(Offset, 0)
-        Sleeve.Visible = true
+        local TweenInfo = Library.TabTransitionInfo or TweenInfo.new(0.22, Enum.EasingStyle.Quad, Enum.EasingDirection.Out)
+        local Offset = Library.TabSwipeOffset or 26
+        local SwipeFrom = string.lower(Library.TabSwipeFrom or "bottom")
+        local StartPosition
 
-        local Tween = TweenService:Create(Sleeve, Info, {
+        if SwipeFrom == "left" then
+            StartPosition = UDim2.fromOffset(-Offset, 0)
+        elseif SwipeFrom == "top" then
+            StartPosition = UDim2.fromOffset(0, -Offset)
+        elseif SwipeFrom == "right" then
+            StartPosition = UDim2.fromOffset(Offset, 0)
+        else -- bottom (Default)
+            StartPosition = UDim2.fromOffset(0, Offset)
+        end
+
+        TabCanvas.ZIndex = BaseZIndex + 1
+        TabCanvas.GroupTransparency = 1
+        TabCanvas.Position = StartPosition
+        TabCanvas.Visible = true
+
+        local Tween = TweenService:Create(TabCanvas, TweenInfo, {
             GroupTransparency = 0,
-            Position = UDim2.fromScale(0, 0),
+            Position = UDim2.fromScale(0, 0)
         })
-        ActiveTabWipeTweens[Sleeve] = Tween
+
+        ActiveTabTweens[TabCanvas] = Tween
         Tween:Play()
 
-        local Connection
-        Connection = Tween.Completed:Connect(function(PlaybackState)
+        local Connection; Connection = Tween.Completed:Connect(function(PlaybackState)
             if Connection then
                 Connection:Disconnect()
             end
-            if ActiveTabWipeTweens[Sleeve] == Tween then
-                ActiveTabWipeTweens[Sleeve] = nil
+
+            if ActiveTabTweens[TabCanvas] == Tween then
+                ActiveTabTweens[TabCanvas] = nil
             end
+
             if PlaybackState == Enum.PlaybackState.Cancelled then
                 return
             end
-            Sleeve.ZIndex = BaseZIndex
+
+            TabCanvas.ZIndex = BaseZIndex
             if OnComplete then
                 OnComplete()
             end
         end)
     else
-        Sleeve.GroupTransparency = 1
-        Sleeve.Visible = false
-        Sleeve.Position = UDim2.fromScale(0, 0)
-        Sleeve.ZIndex = BaseZIndex
+        TabCanvas.GroupTransparency = 1
+        TabCanvas.Visible = false
+        TabCanvas.Position = UDim2.fromScale(0, 0)
+        TabCanvas.ZIndex = BaseZIndex
+
         if OnComplete then
             OnComplete()
         end
@@ -2342,7 +2370,7 @@ function Library:AddContextMenu(
     ActiveCallback: (Active: boolean) -> ()?,
     IgnoreCornerRadius: boolean?,
     SpecificCornersOnly: ("top" | "bottom" | "no_left" | "no_top_left")?, -- stupid way of doing this
-    Animated: boolean?
+    AnimationType: ("Dropdown" | "none")?
 )
     local Menu
     local ParentGui = Holder:FindFirstAncestorOfClass("ScreenGui")
@@ -2441,8 +2469,18 @@ function Library:AddContextMenu(
 
         Size = Size,
 
-        Animated = Animated == true,
         OpenCloseTween = nil,
+        Animated = function()
+            if not AnimationType or AnimationType == "none" then
+                return false
+            end
+
+            if not (Library.Animations and Library.Animations[AnimationType] == true) then
+                return false
+            end
+            
+            return true, Library[string.format("%sTransitionInfo", AnimationType)] or TweenInfo.new(0.18, Enum.EasingStyle.Quad, Enum.EasingDirection.Out)
+        end
     }
 
     if List then
@@ -2484,28 +2522,32 @@ function Library:AddContextMenu(
             Table.OpenCloseTween = nil
         end
 
-        if Table.Animated and Library.Animations and Library.Animations.Dropdown then
-            Menu.Size = UDim2.new(TargetSize.X.Scale, TargetSize.X.Offset, 0, 0)
-            Menu.Visible = true
+        local IsAnimated, TweenInfo = Table.Animated()
+        if IsAnimated == true then
+            if AnimationType == "Dropdown" then
+                Menu.Size = UDim2.new(TargetSize.X.Scale, TargetSize.X.Offset, 0, 0)
+                Menu.Visible = true
 
-            local Info = Library.DropdownTransitionInfo
-                or TweenInfo.new(0.18, Enum.EasingStyle.Quad, Enum.EasingDirection.Out)
+                local Tween = TweenService:Create(Menu, TweenInfo, { Size = TargetSize })
+                Table.OpenCloseTween = Tween
 
-            local Tween = TweenService:Create(Menu, Info, { Size = TargetSize })
-            Table.OpenCloseTween = Tween
+                local Connection; Connection = Library:GiveSignal(Tween.Completed:Once(function()
+                    if Connection then
+                        Connection:Disconnect()
+                    end
 
-            local Connection
-            Connection = Tween.Completed:Connect(function()
-                if Connection then
-                    Connection:Disconnect()
-                end
-                if Table.OpenCloseTween == Tween then
-                    Table.OpenCloseTween = nil
-                end
-            end)
+                    if Table.OpenCloseTween == Tween then
+                        Table.OpenCloseTween = nil
+                    end
+                end))
 
-            Tween:Play()
-        else
+                Tween:Play()
+            else
+                IsAnimated = false
+            end
+        end
+
+        if IsAnimated == false then
             Menu.Size = TargetSize
             Menu.Visible = true
         end
@@ -2538,8 +2580,10 @@ function Library:AddContextMenu(
             Table.Signal:Disconnect()
             Table.Signal = nil
         end
+
         Table.Active = false
         CurrentMenu = nil
+
         if typeof(ActiveCallback) == "function" then
             Library:SafeCallback(ActiveCallback, false)
         end
@@ -2549,29 +2593,34 @@ function Library:AddContextMenu(
             Table.OpenCloseTween = nil
         end
 
-        if Table.Animated and Library.Animations and Library.Animations.Dropdown then
-            local CurrentSize = Menu.Size
-            local CollapsedSize = UDim2.new(CurrentSize.X.Scale, CurrentSize.X.Offset, 0, 0)
+        local IsAnimated, TweenInfo = Table.Animated()
+        if IsAnimated == true then
+            if AnimationType == "Dropdown" then
+                local CurrentSize = Menu.Size
+                local CollapsedSize = UDim2.new(CurrentSize.X.Scale, CurrentSize.X.Offset, 0, 0)
 
-            local Info = Library.DropdownTransitionInfo
-                or TweenInfo.new(0.18, Enum.EasingStyle.Quad, Enum.EasingDirection.Out)
+                local Tween = TweenService:Create(Menu, TweenInfo, { Size = CollapsedSize })
+                Table.OpenCloseTween = Tween
 
-            local Tween = TweenService:Create(Menu, Info, { Size = CollapsedSize })
-            Table.OpenCloseTween = Tween
+                local Connection; Connection = Library:GiveSignal(Tween.Completed:Once(function(PlaybackState)
+                    if Connection then
+                        Connection:Disconnect()
+                    end
 
-            local Connection
-            Connection = Tween.Completed:Connect(function(PlaybackState)
-                if Connection then
-                    Connection:Disconnect()
-                end
-                if Table.OpenCloseTween == Tween then
-                    Table.OpenCloseTween = nil
-                end
-                Menu.Visible = false
-            end)
+                    if Table.OpenCloseTween == Tween then
+                        Table.OpenCloseTween = nil
+                    end
 
-            Tween:Play()
-        else
+                    Menu.Visible = false
+                end))
+
+                Tween:Play()
+            else
+                IsAnimated = false
+            end
+        end
+
+        if IsAnimated == false then
             Menu.Visible = false
         end
     end
@@ -3413,6 +3462,10 @@ do
         end
 
         function KeyPicker:DoClick()
+            if Library.IsPicking then
+                return
+            end
+
             if KeyPicker.Mode == "Press" then
                 if KeyPicker.Toggled and Info.WaitForCallback == true then
                     return
@@ -3426,6 +3479,10 @@ do
 
             if IsForButton then
                 Library:SafeCallback(ParentObj.Func, KeyPicker.Toggled)
+            end
+
+            if Library.ToggleKeybind == KeyPicker and Library.Toggle then
+                Library:Toggle()
             end
 
             if KeyPicker.Mode == "Press" then
@@ -3468,8 +3525,10 @@ do
             end
 
             local NewModifiers = ConvertToInputModifiers(KeyPicker.Modifiers)
-            Library:SafeCallback(KeyPicker.ChangedCallback, KeyCode, NewModifiers)
-            Library:SafeCallback(KeyPicker.Changed, KeyCode, NewModifiers)
+            if not Library.IsPicking then
+                Library:SafeCallback(KeyPicker.ChangedCallback, KeyCode, NewModifiers)
+                Library:SafeCallback(KeyPicker.Changed, KeyCode, NewModifiers)
+            end
 
             KeyPicker:Update()
         end
@@ -3482,6 +3541,10 @@ do
         local SetPickingState = function(State)
             Picking = State
             Library.IsPicking = State
+
+            if ParentObj then
+                ParentObj.AnyKeyPickerPicking = Picking
+            end
 
             if IsForButton then
                 ToggleLabel.Visible = not Picking
@@ -3505,139 +3568,141 @@ do
                 Picker.Size = IsForButton and UDim2.new(0, 29, 1, 0) or UDim2.fromOffset(29, 18)
             end
 
-            -- Wait for an non modifier key --
-            local Input
+            -- Wait for any input --
             local ActiveModifiers = {}
+            local CurrentInput = nil
 
-            local GetInput = nil; GetInput = function()
-                Input = UserInputService.InputBegan:Wait()
-                if UserInputService:GetFocusedTextBox() ~= nil then
+            local IsValidInput = function(InputObj)
+                if InputObj.KeyCode == Enum.KeyCode.Escape then
                     return true
                 end
 
-                if Input.KeyCode == Enum.KeyCode.Escape then
-                    return false
-                end
-
-                local IsMod = IsModifierInput(Input)
+                local IsMod = IsModifierInput(InputObj)
                 local KeyName
-                if SpecialKeysInput[Input.UserInputType] ~= nil then
-                    KeyName = SpecialKeysInput[Input.UserInputType]
-                elseif Input.UserInputType == Enum.UserInputType.Keyboard then
+                if SpecialKeysInput[InputObj.UserInputType] ~= nil then
+                    KeyName = SpecialKeysInput[InputObj.UserInputType]
+                elseif InputObj.UserInputType == Enum.UserInputType.Keyboard then
                     if IsMod then
-                        KeyName = ModifiersInput[Input.KeyCode]
+                        KeyName = ModifiersInput[InputObj.KeyCode]
                     else
-                        KeyName = Input.KeyCode.Name
+                        KeyName = InputObj.KeyCode.Name
                     end
                 end
 
                 if KeyName then
                     if IsMod then
                         if KeyPicker.WhitelistedModifiers and #KeyPicker.WhitelistedModifiers > 0 and not table.find(KeyPicker.WhitelistedModifiers, KeyName) then
-                            return GetInput()
+                            return false
                         end
 
                         if KeyPicker.BlacklistedModifiers and table.find(KeyPicker.BlacklistedModifiers, KeyName) then
-                            return GetInput()
+                            return false
                         end
                     else
                         if KeyPicker.Whitelisted and #KeyPicker.Whitelisted > 0 and not table.find(KeyPicker.Whitelisted, KeyName) then
-                            return GetInput()
+                            return false
                         end
 
                         if KeyPicker.Blacklisted and table.find(KeyPicker.Blacklisted, KeyName) then
-                            return GetInput()
+                            return false
                         end
                     end
                 end
 
-                return false
+                return true
             end
 
-            repeat
-                task.wait()
-
-                -- Wait for any input --
-                if IsForButton and SlideOverflow then
-                    KeyPicker:Display("...")
-                else
-                    Picker.Text = "..."
-                    Picker.Size = IsForButton and UDim2.new(0, 29, 1, 0) or UDim2.fromOffset(29, 18)
-                end
-
-                if GetInput() then
+            -- Wait for the first valid InputBegan --
+            while true do
+                local InputObj = UserInputService.InputBegan:Wait()
+                if UserInputService:GetFocusedTextBox() ~= nil then
                     SetPickingState(false)
                     return
                 end
 
-                -- Escape --
-                if Input.KeyCode == Enum.KeyCode.Escape then
+                if IsValidInput(InputObj) then
+                    CurrentInput = InputObj
+                    break
+                end
+            end
+
+            -- If it's a modifier key, we wait for either its release or another input --
+            while IsModifierInput(CurrentInput) do
+                if CurrentInput.KeyCode == Enum.KeyCode.Escape then
                     break
                 end
 
-                -- Handle modifier keys --
-                if IsModifierInput(Input) then
-                    local StopLoop = false
-
-                    repeat
-                        task.wait()
-                        if UserInputService:IsKeyDown(Input.KeyCode) then
-                            task.wait(0.075)
-
-                            if UserInputService:IsKeyDown(Input.KeyCode) then
-                                -- Add modifier to the key list --
-                                if not table.find(ActiveModifiers, ModifiersInput[Input.KeyCode]) then
-                                    ActiveModifiers[#ActiveModifiers + 1] = ModifiersInput[Input.KeyCode]
-                                    KeyPicker:Display(table.concat(ActiveModifiers, " + ") .. " + ...")
-                                end
-
-                                -- Wait for another input --
-                                if GetInput() then
-                                    StopLoop = true
-                                    break -- Invalid Input
-                                end
-
-                                -- Escape --
-                                if Input.KeyCode == Enum.KeyCode.Escape then
-                                    break
-                                end
-
-                                -- Stop loop if its a normal key --
-                                if not IsModifierInput(Input) then
-                                    break
-                                end
-                            else
-                                if not table.find(ActiveModifiers, ModifiersInput[Input.KeyCode]) then
-                                    break -- Modifier is meant to be used as a normal key --
-                                end
-                            end
-                        end
-                    until false
-
-                    if StopLoop then
-                        SetPickingState(false)
-                        return
-                    end
+                -- Display the current state including the current modifier key --
+                local ModName = ModifiersInput[CurrentInput.KeyCode]
+                if ModName then
+                    local text = if #ActiveModifiers > 0 then table.concat(ActiveModifiers, " + ") .. " + " .. ModName .. " + ..." else ModName .. " + ..."
+                    KeyPicker:Display(text)
                 end
 
-                break -- Input found, end loop
-            until false
+                local NextInput = nil
+                local Released = false
 
-            local Key = "Unknown"
-            if SpecialKeysInput[Input.UserInputType] ~= nil then
-                Key = SpecialKeysInput[Input.UserInputType]
-            elseif Input.UserInputType == Enum.UserInputType.Keyboard then
-                Key = Input.KeyCode == Enum.KeyCode.Escape and "None" or Input.KeyCode.Name
+                local BeganConn
+                local EndedConn
+
+                BeganConn = UserInputService.InputBegan:Connect(function(InputObj)
+                    if UserInputService:GetFocusedTextBox() ~= nil then
+                        return
+                    end
+                    if IsValidInput(InputObj) then
+                        NextInput = InputObj
+                    end
+                end)
+
+                EndedConn = UserInputService.InputEnded:Connect(function(InputObj)
+                    if InputObj.KeyCode == CurrentInput.KeyCode then
+                        Released = true
+                    end
+                end)
+
+                repeat
+                    task.wait()
+                until Released or NextInput or UserInputService:GetFocusedTextBox() ~= nil or Library.Unloaded
+
+                if BeganConn then BeganConn:Disconnect() end
+                if EndedConn then EndedConn:Disconnect() end
+
+                if UserInputService:GetFocusedTextBox() ~= nil or Library.Unloaded then
+                    SetPickingState(false)
+                    return
+                end
+
+                if Released then
+                    break -- Use modifier key as bind
+                elseif NextInput then
+                    -- Add another modifier or continue to normal key
+                    local OldModName = ModifiersInput[CurrentInput.KeyCode]
+                    if OldModName and not table.find(ActiveModifiers, OldModName) then
+                        ActiveModifiers[#ActiveModifiers + 1] = OldModName
+                    end
+
+                    CurrentInput = NextInput
+                    if CurrentInput.KeyCode == Enum.KeyCode.Escape then
+                        break
+                    end
+                end
             end
 
-            ActiveModifiers = if Input.KeyCode == Enum.KeyCode.Escape or Key == "Unknown" then {} else ActiveModifiers
+            local Key = "Unknown"
+            if SpecialKeysInput[CurrentInput.UserInputType] ~= nil then
+                Key = SpecialKeysInput[CurrentInput.UserInputType]
+            elseif CurrentInput.UserInputType == Enum.UserInputType.Keyboard then
+                Key = CurrentInput.KeyCode == Enum.KeyCode.Escape and "None" or CurrentInput.KeyCode.Name
+            end
 
-            KeyPicker.Toggled = false
+            ActiveModifiers = if CurrentInput.KeyCode == Enum.KeyCode.Escape or Key == "Unknown" then {} else ActiveModifiers
+
+            KeyPicker.Toggled = if ParentObj.Type == "Toggle" then ParentObj.Value else false
             KeyPicker:SetValue({ Key, KeyPicker.Mode, ActiveModifiers })
 
             repeat
                 task.wait()
-            until not IsInputDown(Input) or UserInputService:GetFocusedTextBox()
+            until not IsInputDown(CurrentInput) or UserInputService:GetFocusedTextBox()
 
             SetPickingState(false)
         end)
@@ -4966,7 +5031,9 @@ do
             Risky = Info.Risky,
             Disabled = Info.Disabled,
             Visible = Info.Visible,
+
             Addons = {},
+            AnyKeyPickerPicking = false,
 
             Variant = "Checkbox",
             Type = "Toggle",
@@ -5081,8 +5148,11 @@ do
             end
 
             Library:UpdateDependencyBoxes()
-            Library:SafeCallback(Toggle.Callback, Toggle.Value)
-            Library:SafeCallback(Toggle.Changed, Toggle.Value)
+
+            if not Toggle.AnyKeyPickerPicking then
+                Library:SafeCallback(Toggle.Callback, Toggle.Value)
+                Library:SafeCallback(Toggle.Changed, Toggle.Value)
+            end
         end
 
         function Toggle:SetDisabled(Disabled: boolean)
@@ -5213,7 +5283,9 @@ do
             Risky = Info.Risky,
             Disabled = Info.Disabled,
             Visible = Info.Visible,
+
             Addons = {},
+            AnyKeyPickerPicking = false,
 
             Variant = "Switch",
             Type = "Toggle",
@@ -5344,8 +5416,11 @@ do
             end
 
             Library:UpdateDependencyBoxes()
-            Library:SafeCallback(Toggle.Callback, Toggle.Value)
-            Library:SafeCallback(Toggle.Changed, Toggle.Value)
+
+            if not Toggle.AnyKeyPickerPicking then
+                Library:SafeCallback(Toggle.Callback, Toggle.Value)
+                Library:SafeCallback(Toggle.Changed, Toggle.Value)
+            end
         end
 
         function Toggle:SetDisabled(Disabled: boolean)
@@ -6284,7 +6359,7 @@ do
             end,
             false,
             "bottom",
-            true
+            "Dropdown"
         )
         Dropdown.Menu = MenuTable
 
@@ -8093,23 +8168,6 @@ function Library:Notify(...)
 end
 
 function Library:CreateWindow(WindowInfo)
-    --// Old Naming (pre-Validate) \\--
-    if typeof(WindowInfo) == "table" then
-        if typeof(WindowInfo.Animations) == "boolean" then
-            local ToggleWindow = WindowInfo.Animations
-            WindowInfo.Animations = {
-                ToggleWindow = ToggleWindow,
-                TabSwitch = ToggleWindow,
-            }
-        end
-        if typeof(WindowInfo.TabSwitch) == "boolean" and typeof(WindowInfo.Animations) ~= "table" then
-            WindowInfo.Animations = {}
-        end
-        if typeof(WindowInfo.TabSwitch) == "boolean" and typeof(WindowInfo.Animations) == "table" and WindowInfo.Animations.TabSwitch == nil then
-            WindowInfo.Animations.TabSwitch = WindowInfo.TabSwitch
-        end
-    end
-
     WindowInfo = Library:Validate(WindowInfo, Templates.Window)
     local ViewportSize: Vector2 = workspace.CurrentCamera.ViewportSize
     if RunService:IsStudio() and ViewportSize.X <= 5 and ViewportSize.Y <= 5 then
@@ -8153,14 +8211,15 @@ function Library:CreateWindow(WindowInfo)
     Library.Scheme.Font = WindowInfo.Font
     Library.ToggleKeybind = WindowInfo.ToggleKeybind
     Library.GlobalSearch = WindowInfo.GlobalSearch
+    
     Library.Animations = WindowInfo.Animations
-
     Library.TabTransitionInfo = TweenInfo.new(
         math.max(0, WindowInfo.TabTransitionTime or 0.22),
         Enum.EasingStyle.Quad,
         Enum.EasingDirection.Out
     )
-    Library.TabWipeOffset = WindowInfo.TabWipeOffset or 26
+    Library.TabSwipeOffset = math.max(1, WindowInfo.TabSwipeOffset or 26)
+    Library.TabSwipeFrom = WindowInfo.TabSwipeFrom or "right"
 
     local IsDefaultSearchbarSize = WindowInfo.SearchbarSize == UDim2.fromScale(1, 1)
     local MainFrame
@@ -8179,6 +8238,7 @@ function Library:CreateWindow(WindowInfo)
     local BackgroundImage
     local BottomBackground
     local FooterLabel
+    local TopBar
 
     local InitialLeftWidth = math.ceil(WindowInfo.Size.X.Offset * 0.3)
     local IsCompact = WindowInfo.SidebarCompacted
@@ -8255,7 +8315,7 @@ function Library:CreateWindow(WindowInfo)
         end
 
         --// Top Bar \\-
-        local TopBar = New("Frame", {
+        TopBar = New("Frame", {
             BackgroundTransparency = 1,
             Size = UDim2.new(1, 0, 0, 48),
             Parent = MainFrame,
@@ -8546,10 +8606,13 @@ function Library:CreateWindow(WindowInfo)
     --// Window Table \\--
     local Window = {}
     local Fading = false
-    local TransparencyCache = {}
 
     local function SetUICorner(UICorner, Corner, HalfCurrent, HalfValue, Value)
         local Current = UICorner[Corner]
+        if Current.Offset == 0 and Current.Scale == 0 then
+            return
+        end
+
         UICorner[Corner] = Current.Offset == HalfCurrent and HalfValue or Value
     end
 
@@ -8621,6 +8684,38 @@ function Library:CreateWindow(WindowInfo)
             for _, Tabbox in Tab.Tabboxes do
                 Tabbox:UpdateCorners()
             end
+        end
+    end
+
+    function Window:SetAnimations(Animations: { [string]: boolean }?, TabTransitionTime: number?, TabSwipeOffset: number?, TabSwipeFrom: ("left" | "right" | "top" | "bottom" | string)?)
+        if typeof(Animations) == "table" then
+            WindowInfo.Animations = Animations
+            Library.Animations = Animations
+        end
+
+        if typeof(TabTransitionTime) == "number" then
+            local TweenInfo = TweenInfo.new(
+                math.max(0, TabTransitionTime or 0.22),
+                Enum.EasingStyle.Quad,
+                Enum.EasingDirection.Out
+            )
+
+            WindowInfo.TabTransitionInfo = TweenInfo
+            Library.TabTransitionInfo = TweenInfo
+        end
+
+        if typeof(TabSwipeOffset) == "number" then
+            TabSwipeOffset = math.max(1, TabSwipeOffset)
+
+            WindowInfo.TabSwipeOffset = TabSwipeOffset
+            Library.TabSwipeOffset = TabSwipeOffset
+        end
+
+        if typeof(TabSwipeFrom) == "string" then
+            TabSwipeFrom = string.lower(TabSwipeFrom)
+
+            WindowInfo.TabSwipeFrom = TabSwipeFrom
+            Library.TabSwipeFrom = TabSwipeFrom
         end
     end
 
@@ -8717,7 +8812,7 @@ function Library:CreateWindow(WindowInfo)
         local TabIcon
 
         local TabContainer
-        local TabSleeve
+        local TabCanvas
         local TabLeft
         local TabRight
 
@@ -8770,12 +8865,23 @@ function Library:CreateWindow(WindowInfo)
                 Icon = TabIcon,
             })
 
+            --// Tab Canvas \\--
+            TabCanvas = New("CanvasGroup", {
+                BackgroundTransparency = 1,
+                ClipsDescendants = true,
+                GroupTransparency = 0,
+                Size = UDim2.fromScale(1, 1),
+                Visible = false,
+                Parent = Container,
+            })
+
             --// Tab Container \\--
             TabContainer = New("Frame", {
                 BackgroundTransparency = 1,
+                Position = UDim2.fromScale(0, 0),
                 Size = UDim2.fromScale(1, 1),
                 Visible = true,
-                Parent = Container,
+                Parent = TabCanvas,
             })
 
             TabLeft = New("ScrollingFrame", {
@@ -8846,8 +8952,6 @@ function Library:CreateWindow(WindowInfo)
                 })
             end
         end
-
-        TabSleeve = Library:WrapTabSleeve(TabContainer, Container)
 
         --// Warning Box \\--
         local WarningBoxHolder = New("Frame", {
@@ -8938,14 +9042,13 @@ function Library:CreateWindow(WindowInfo)
 
         --// Tab Table \\--
         local Tab = {
+            Description = Description,
+
             Connections = {},
             Destroyed = false,
 
             Window = Window,
-            Groupboxes = {},
-            Tabboxes = {},
-            DependencyGroupboxes = {},
-            Description = Description,
+            Canvas = TabCanvas,
             Sides = {
                 TabLeft,
                 TabRight,
@@ -8957,6 +9060,10 @@ function Library:CreateWindow(WindowInfo)
                 Title = "WARNING",
                 Text = "",
             },
+
+            Groupboxes = {},
+            Tabboxes = {},
+            DependencyGroupboxes = {},
         }
 
         function Tab:UpdateWarningBox(Info)
@@ -9651,7 +9758,7 @@ function Library:CreateWindow(WindowInfo)
                 Window:ShowTabInfo(Name, Description)
             end
 
-            Library:PlayTabWipe(TabSleeve, true)
+            Library:PlayTabAnimation(TabCanvas, true)
             Tab:RefreshSides()
 
             Library.ActiveTab = Tab
@@ -9665,16 +9772,18 @@ function Library:CreateWindow(WindowInfo)
             TweenService:Create(TabButton, Library.TweenInfo, {
                 BackgroundTransparency = 1,
             }):Play()
+
             TweenService:Create(TabLabel, Library.TweenInfo, {
                 TextTransparency = 0.5,
             }):Play()
+
             if TabIcon then
                 TweenService:Create(TabIcon, Library.TweenInfo, {
                     ImageTransparency = 0.5,
                 }):Play()
             end
-            Library:PlayTabWipe(TabSleeve, false)
 
+            Library:PlayTabAnimation(TabCanvas, false)
             Window:HideTabInfo()
 
             Library.ActiveTab = nil
@@ -9717,8 +9826,8 @@ function Library:CreateWindow(WindowInfo)
                 end
             end
 
-            if TabSleeve then
-                TabSleeve:Destroy()
+            if TabCanvas then
+                TabCanvas:Destroy()
             elseif TabContainer then
                 TabContainer:Destroy()
             end
@@ -9777,8 +9886,8 @@ function Library:CreateWindow(WindowInfo)
         local TabLabel
         local TabIcon
 
+        local TabCanvas
         local TabContainer
-        local TabSleeve
 
         Icon = if Icon == "key" then KeyIcon else Library:GetCustomIcon(Icon)
         do
@@ -9828,15 +9937,26 @@ function Library:CreateWindow(WindowInfo)
                 Icon = TabIcon,
             })
 
+            --// Tab Canvas \\--
+            TabCanvas = New("CanvasGroup", {
+                BackgroundTransparency = 1,
+                ClipsDescendants = true,
+                GroupTransparency = 0,
+                Size = UDim2.fromScale(1, 1),
+                Visible = false,
+                Parent = Container,
+            })
+
             --// Tab Container \\--
             TabContainer = New("ScrollingFrame", {
                 AutomaticCanvasSize = Enum.AutomaticSize.Y,
                 BackgroundTransparency = 1,
                 CanvasSize = UDim2.fromScale(0, 0),
                 ScrollBarThickness = 0,
+                Position = UDim2.fromScale(0, 0),
                 Size = UDim2.fromScale(1, 1),
                 Visible = true,
-                Parent = Container,
+                Parent = TabCanvas,
             })
             New("UIListLayout", {
                 HorizontalAlignment = Enum.HorizontalAlignment.Center,
@@ -9851,14 +9971,15 @@ function Library:CreateWindow(WindowInfo)
             })
         end
 
-        TabSleeve = Library:WrapTabSleeve(TabContainer, Container)
-
         --// Tab Table \\--
         local Tab = {
-            Elements = {},
             Description = Description,
             IsKeyTab = true,
+
+            Elements = {},
+
             Window = Window,
+            Canvas = TabCanvas
         }
 
         function Tab:AddKeyBox(Callback)
@@ -9930,8 +10051,8 @@ function Library:CreateWindow(WindowInfo)
         end
         
         function Tab:Destroy()
-            if TabSleeve then
-                TabSleeve:Destroy()
+            if TabCanvas then
+                TabCanvas:Destroy()
             elseif TabContainer then
                 TabContainer:Destroy()
             end
@@ -9981,15 +10102,18 @@ function Library:CreateWindow(WindowInfo)
             TweenService:Create(TabButton, Library.TweenInfo, {
                 BackgroundTransparency = 0,
             }):Play()
+
             TweenService:Create(TabLabel, Library.TweenInfo, {
                 TextTransparency = 0,
             }):Play()
+
             if TabIcon then
                 TweenService:Create(TabIcon, Library.TweenInfo, {
                     ImageTransparency = 0,
                 }):Play()
             end
-            Library:PlayTabWipe(TabSleeve, true)
+
+            Library:PlayTabAnimation(TabCanvas, true)
 
             if Description then
                 Window:ShowTabInfo(Name, Description)
@@ -10008,16 +10132,18 @@ function Library:CreateWindow(WindowInfo)
             TweenService:Create(TabButton, Library.TweenInfo, {
                 BackgroundTransparency = 1,
             }):Play()
+
             TweenService:Create(TabLabel, Library.TweenInfo, {
                 TextTransparency = 0.5,
             }):Play()
+
             if TabIcon then
                 TweenService:Create(TabIcon, Library.TweenInfo, {
                     ImageTransparency = 0.5,
                 }):Play()
             end
-            Library:PlayTabWipe(TabSleeve, false)
 
+            Library:PlayTabAnimation(TabCanvas, false)
             Window:HideTabInfo()
 
             Library.ActiveTab = nil
@@ -10537,6 +10663,26 @@ function Library:CreateWindow(WindowInfo)
         return Dialog
     end
 
+    local function FadeInstance(Desc, Properties)
+        local Cache = TransparencyCache[Desc]
+        if not Cache then
+            Cache = {}
+            TransparencyCache[Desc] = Cache
+        end
+
+        for _, Prop in Properties do
+            if not Library.Toggled then
+                Cache[Prop] = Desc[Prop]
+            end
+
+            if Cache[Prop] ~= nil and Cache[Prop] ~= 1 then
+                TweenService:Create(Desc, Library.WindowAnimationInfo, {
+                    [Prop] = Library.Toggled and Cache[Prop] or 1,
+                }):Play()
+            end
+        end
+    end
+
     function Window:Toggle(Value: boolean?)
         if Fading then
             return
@@ -10558,7 +10704,7 @@ function Library:CreateWindow(WindowInfo)
             Library.Toggled = not Library.Toggled
         end
 
-        if Library.Animations and Library.Animations.ToggleWindow then
+        if Library.Animations and Library.Animations.ToggleWindow == true then
             local FadeTime = Library.WindowAnimationInfo.Time
             Fading = true
 
@@ -10566,44 +10712,33 @@ function Library:CreateWindow(WindowInfo)
                 MainFrame.Visible = true
             end
 
-            local function FadeInstance(Desc, Properties)
-                local Cache = TransparencyCache[Desc]
-                if not Cache then
-                    Cache = {}
-                    TransparencyCache[Desc] = Cache
+            if Library.Toggled then 
+				FadeInstance(MainFrame, { "BackgroundTransparency" })
+				task.wait(FadeTime / 2)
+			else
+				task.delay(FadeTime / 2, FadeInstance, MainFrame, { "BackgroundTransparency" })
+			end
+
+            for _, Instance in MainFrame:GetDescendants() do
+                if Instance == TopBar then
+                    continue
                 end
 
-                for _, Prop in Properties do
-                    if not Library.Toggled then
-                        Cache[Prop] = Desc[Prop]
-                    end
-
-                    if Cache[Prop] ~= nil and Cache[Prop] ~= 1 then
-                        TweenService:Create(Desc, Library.WindowAnimationInfo, {
-                            [Prop] = Library.Toggled and Cache[Prop] or 1,
-                        }):Play()
-                    end
-                end
-            end
-
-            FadeInstance(MainFrame, { "BackgroundTransparency" })
-
-            for _, Desc in MainFrame:GetDescendants() do
                 local Properties = {}
 
-                if Desc:IsA("GuiObject") then
+                if Instance:IsA("GuiObject") then
                     table.insert(Properties, "BackgroundTransparency")
                 end
 
-                if Desc:IsA("ImageLabel") or Desc:IsA("ImageButton") then
+                if Instance:IsA("ImageLabel") or Instance:IsA("ImageButton") then
                     table.insert(Properties, "ImageTransparency")
-                elseif Desc:IsA("TextLabel") or Desc:IsA("TextBox") or Desc:IsA("TextButton") then
+                elseif Instance:IsA("TextLabel") or Instance:IsA("TextBox") or Instance:IsA("TextButton") then
                     table.insert(Properties, "TextTransparency")
-                elseif Desc:IsA("UIStroke") then
+                elseif Instance:IsA("UIStroke") then
                     table.insert(Properties, "Transparency")
                 end
 
-                FadeInstance(Desc, Properties)
+                FadeInstance(Instance, Properties)
             end
 
             task.delay(FadeTime, function()
@@ -10777,28 +10912,8 @@ function Library:CreateWindow(WindowInfo)
     end
 
     --// Execution \\--
-    SearchBox:GetPropertyChangedSignal("Text"):Connect(function()
+    Library:GiveSignal(SearchBox:GetPropertyChangedSignal("Text"):Connect(function()
         Library:UpdateSearch(SearchBox.Text)
-    end)
-
-    Library:GiveSignal(UserInputService.InputBegan:Connect(function(Input: InputObject)
-        if Library.Unloaded then
-            return
-        end
-
-        if UserInputService:GetFocusedTextBox() then
-            return
-        end
-
-        if
-            (
-                typeof(Library.ToggleKeybind) == "table"
-                and Library.ToggleKeybind.Type == "KeyPicker"
-                and Input.KeyCode.Name == Library.ToggleKeybind.Value
-            ) or Input.KeyCode == Library.ToggleKeybind
-        then
-            Library.Toggle()
-        end
     end))
 
     Library:GiveSignal(UserInputService.WindowFocused:Connect(function()
@@ -11592,6 +11707,9 @@ function Library:Unload()
     table.clear(Library.DraggableElements)
     table.clear(Library.KeybindToggles)
     table.clear(Library.DependencyBoxes)
+
+    table.clear(TransparencyCache)
+    table.clear(ActiveTabTweens)
     
     Library.Toggle = function(...) end
     Library.ScreenGui = nil


### PR DESCRIPTION
## Included animations
Click on the below two animations to view a GIF example
- [Linoria-based window open/close](https://github.com/user-attachments/assets/116bc93a-fbde-40d6-9be3-986fc039ab9d)
- [Tab Switching: Fade/Wipe Transition](https://github.com/user-attachments/assets/dcbee83d-ae09-4bfb-a5d2-99bcda0cc759)

# New Animation: Down/Up Animation for Dropdown Lists
Dropdown lists used to snap open/closed instantly, which stood out next to the other animated UI. Opening now grows the list down from the dropdown's own edge, and closing shrinks it back up into that same point, instead of just toggling visibility.

- Added `Library.Animations.Dropdown` (opt-in, default `false`) and `Library.DropdownTransitionInfo` for timing/easing.
- `AddContextMenu` gained an optional `Animated` param (only Dropdown opts in for now; other menus are unaffected).
- Animations from [Tab Switching: Fade/Wipe Transition](https://github.com/deividcomsono/Obsidian/pull/133) have been renamed for simplicity:
```lua
local Window = Library:CreateWindow({
	Animations = {
        ToggleWindow = true,
        TabSwitch = true,
		Dropdown = true
    }
})
```

<img width="800" height="652" alt="ezgif-299d8def58cd74ae" src="https://github.com/user-attachments/assets/53309a70-ffad-4722-b13d-cb8529b51277" />
<sub>Remaining animations: 3</sub>