### PR TITLE
Notification queue/cap (MaxNotifications)

### DIFF
--- a/Library.lua
+++ b/Library.lua
@@ -8628,6 +8628,10 @@ function Library:CreateWindow(WindowInfo)
 
     local function SetUICorner(UICorner, Corner, HalfCurrent, HalfValue, Value)
         local Current = UICorner[Corner]
+        if Current.Offset == 0 and Current.Scale == 0 then
+            return
+        end
+
         UICorner[Corner] = Current.Offset == HalfCurrent and HalfValue or Value
     end
 

--- a/Library.lua
+++ b/Library.lua
@@ -8628,10 +8628,6 @@ function Library:CreateWindow(WindowInfo)
 
     local function SetUICorner(UICorner, Corner, HalfCurrent, HalfValue, Value)
         local Current = UICorner[Corner]
-        if Current.Offset == 0 and Current.Scale == 0 then
-            return
-        end
-
         UICorner[Corner] = Current.Offset == HalfCurrent and HalfValue or Value
     end
 

--- a/Library.lua
+++ b/Library.lua
@@ -8738,6 +8738,26 @@ function Library:CreateWindow(WindowInfo)
         end
     end
 
+    function Window:SetMaxNotifications(Amount: number)
+        assert(typeof(Amount) == "number", "Expected number for Amount got: " .. typeof(Amount))
+
+        Amount = math.floor(Amount)
+
+        WindowInfo.MaxNotifications = Amount
+        Library.MaxNotifications = Amount
+
+        -- // Trim any notifications that already exceed the new limit \\ --
+        if Amount > 0 then
+            while #Library.NotificationQueue > Amount do
+                local Oldest = table.remove(Library.NotificationQueue, 1)
+                local OldestData = Library.Notifications[Oldest]
+                if OldestData and not OldestData.Persist and not OldestData.Destroyed then
+                    OldestData:Destroy()
+                end
+            end
+        end
+    end
+
     local function ApplyCompact()
         IsCompact = Window:GetSidebarWidth() == WindowInfo.SidebarCompactWidth
         if WindowInfo.DisableCompactingSnap then

--- a/Library.lua
+++ b/Library.lua
@@ -194,6 +194,7 @@ local Library = {
     --// Notifications \\--
     Notifications = {},
     NotificationQueue = {},
+    PendingNotifications = {},
     MaxNotifications = 10,
     NotifySide = "Right",
     NotifyTweenInfo = TweenInfo.new(0.25, Enum.EasingStyle.Quad, Enum.EasingDirection.Out),
@@ -8008,44 +8009,9 @@ function Library:SetNotifySide(Side: string)
     Library:UpdateNotificationPositions(true)
 end
 
-function Library:Notify(...)
-    local Data = {}
-    local Info = select(1, ...)
-
-    if typeof(Info) == "table" then
-        Data.Title = tostring(Info.Title)
-        Data.TitleColor = Info.TitleColor
-
-        Data.Description = tostring(Info.Description)
-        Data.DescriptionColor = Info.DescriptionColor
-
-        Data.Time = Info.Time or 5
-        Data.SoundId = Info.SoundId
-        Data.Steps = Info.Steps
-        Data.Persist = Info.Persist
-
-        Data.Icon = Info.Icon
-        Data.BigIcon = Info.BigIcon
-        Data.IconColor = Info.IconColor
-
-        Data.Volume = tonumber(Info.Volume) or 3
-    else
-        Data.Description = tostring(Info)
-        Data.Time = select(2, ...) or 5
-        Data.SoundId = select(3, ...)
-        Data.Volume = select(4, ...) or 3
-    end
-    Data.Destroyed = false
-
-    local DeletedInstance = false
-    local DeleteConnection = nil
-    if typeof(Data.Time) == "Instance" then
-        DeleteConnection = Data.Time.Destroying:Connect(function()
-            DeletedInstance = true
-
-            DeleteConnection:Disconnect()
-            DeleteConnection = nil
-        end)
+local function SpawnNotification(Data)
+    if Data.Destroyed then
+        return Data
     end
 
     local FakeBackground = New("Frame", {
@@ -8243,14 +8209,18 @@ function Library:Notify(...)
     end
 
     function Data:Destroy()
+        if Data.Destroyed then
+            return
+        end
         Data.Destroyed = true
 
         if typeof(Data.Time) == "Instance" then
             pcall(Data.Time.Destroy, Data.Time)
         end
 
-        if DeleteConnection then
-            DeleteConnection:Disconnect()
+        if Data._deleteConnection then
+            Data._deleteConnection:Disconnect()
+            Data._deleteConnection = nil
         end
 
         if FakeBackground then
@@ -8276,6 +8246,8 @@ function Library:Notify(...)
                 table.remove(Library.NotificationQueue, Idx)
             end
             FakeBackground:Destroy()
+
+            Library:TryDequeuePending()
         end)
     end
 
@@ -8324,16 +8296,6 @@ function Library:Notify(...)
     Library.Notifications[FakeBackground] = Data
     table.insert(Library.NotificationQueue, FakeBackground)
 
-    if Library.MaxNotifications > 0 then
-        while #Library.NotificationQueue > Library.MaxNotifications do
-            local Oldest = table.remove(Library.NotificationQueue, 1)
-            local OldestData = Library.Notifications[Oldest]
-            if OldestData and not OldestData.Persist and not OldestData.Destroyed then
-                OldestData:Destroy()
-            end
-        end
-    end
-
     Library:UpdateNotificationPositions()
 
     FakeBackground.Visible = true
@@ -8347,7 +8309,7 @@ function Library:Notify(...)
         elseif typeof(Data.Time) == "Instance" then
             repeat
                 task.wait()
-            until DeletedInstance or Data.Destroyed
+            until Data._deletedInstance or Data.Destroyed
         else
             TweenService
                 :Create(TimerFill, TweenInfo.new(Data.Time, Enum.EasingStyle.Linear, Enum.EasingDirection.InOut), {
@@ -8363,6 +8325,105 @@ function Library:Notify(...)
     end)
 
     return Data
+end
+
+function Library:TryDequeuePending()
+    if Library.MaxNotifications <= 0 then
+        while #Library.PendingNotifications > 0 do
+            local NextData = table.remove(Library.PendingNotifications, 1)
+            if not NextData.Destroyed then
+                SpawnNotification(NextData)
+            end
+        end
+        return
+    end
+
+    while #Library.PendingNotifications > 0 and #Library.NotificationQueue < Library.MaxNotifications do
+        local NextData = table.remove(Library.PendingNotifications, 1)
+        if not NextData.Destroyed then
+            SpawnNotification(NextData)
+        end
+    end
+end
+
+function Library:Notify(...)
+    local Data = {}
+    local Info = select(1, ...)
+
+    if typeof(Info) == "table" then
+        Data.Title = tostring(Info.Title)
+        Data.TitleColor = Info.TitleColor
+
+        Data.Description = tostring(Info.Description)
+        Data.DescriptionColor = Info.DescriptionColor
+
+        Data.Time = Info.Time or 5
+        Data.SoundId = Info.SoundId
+        Data.Steps = Info.Steps
+        Data.Persist = Info.Persist
+
+        Data.Icon = Info.Icon
+        Data.BigIcon = Info.BigIcon
+        Data.IconColor = Info.IconColor
+
+        Data.Volume = tonumber(Info.Volume) or 3
+    else
+        Data.Description = tostring(Info)
+        Data.Time = select(2, ...) or 5
+        Data.SoundId = select(3, ...)
+        Data.Volume = select(4, ...) or 3
+    end
+    Data.Destroyed = false
+
+    Data._deletedInstance = false
+    Data._deleteConnection = nil
+    if typeof(Data.Time) == "Instance" then
+        Data._deleteConnection = Data.Time.Destroying:Connect(function()
+            Data._deletedInstance = true
+
+            if Data._deleteConnection then
+                Data._deleteConnection:Disconnect()
+                Data._deleteConnection = nil
+            end
+        end)
+    end
+
+    --// Pending-safe placeholders - overwritten by SpawnNotification once this notification actually gets a slot \\--
+    function Data:ChangeTitle(Text)
+        Data.Title = tostring(Text)
+    end
+    function Data:ChangeDescription(Text)
+        Data.Description = tostring(Text)
+    end
+    function Data:ChangeStep(_NewStep)
+        -- no-op until spawned; there's no timer bar to update yet
+    end
+    function Data:Resize()
+        -- no-op until spawned; there's no UI to resize yet
+    end
+    function Data:Destroy()
+        if Data.Destroyed then
+            return
+        end
+        Data.Destroyed = true
+
+        if Data._deleteConnection then
+            Data._deleteConnection:Disconnect()
+            Data._deleteConnection = nil
+        end
+
+        local Idx = table.find(Library.PendingNotifications, Data)
+        if Idx then
+            table.remove(Library.PendingNotifications, Idx)
+        end
+    end
+
+    if Library.MaxNotifications > 0 and #Library.NotificationQueue >= Library.MaxNotifications then
+        table.insert(Library.PendingNotifications, Data)
+        return Data
+    end
+
+    return SpawnNotification(Data)
 end
 
 function Library:CreateWindow(WindowInfo)
@@ -8937,6 +8998,9 @@ function Library:CreateWindow(WindowInfo)
                 end
             end
         end
+
+        -- // Raising the limit can free up slots for anything still queued \\ --
+        Library:TryDequeuePending()
     end
 
     local function ApplyCompact()
@@ -12007,6 +12071,7 @@ function Library:Unload()
 
     table.clear(Library.Notifications)
     table.clear(Library.NotificationQueue)
+    table.clear(Library.PendingNotifications)
     table.clear(Library.Dialogues)
     table.clear(Library.DraggableElements)
     table.clear(Library.KeybindToggles)

--- a/Library.lua
+++ b/Library.lua
@@ -193,6 +193,8 @@ local Library = {
 
     --// Notifications \\--
     Notifications = {},
+    NotificationQueue = {},
+    MaxNotifications = 10,
     NotifySide = "Right",
     NotifyTweenInfo = TweenInfo.new(0.25, Enum.EasingStyle.Quad, Enum.EasingDirection.Out),
 
@@ -365,6 +367,7 @@ local Templates = {
         CornerRadius = 4,
         NotifySide = "Right",
         ShowCustomCursor = true,
+        MaxNotifications = 10,
 
         Font = Enum.Font.Code,
         ToggleKeybind = Enum.KeyCode.RightControl,
@@ -8091,6 +8094,11 @@ function Library:Notify(...)
 
         task.delay(Library.NotifyTweenInfo.Time, function()
             Library.Notifications[FakeBackground] = nil
+
+            local Idx = table.find(Library.NotificationQueue, FakeBackground)
+            if Idx then
+                table.remove(Library.NotificationQueue, Idx)
+            end
             FakeBackground:Destroy()
         end)
     end
@@ -8135,6 +8143,17 @@ function Library:Notify(...)
     end
 
     Library.Notifications[FakeBackground] = Data
+    table.insert(Library.NotificationQueue, FakeBackground)
+
+    if Library.MaxNotifications > 0 then
+        while #Library.NotificationQueue > Library.MaxNotifications do
+            local Oldest = table.remove(Library.NotificationQueue, 1)
+            local OldestData = Library.Notifications[Oldest]
+            if OldestData and not OldestData.Persist and not OldestData.Destroyed then
+                OldestData:Destroy()
+            end
+        end
+    end
 
     FakeBackground.Visible = true
     TweenService:Create(Holder, Library.NotifyTweenInfo, {
@@ -8206,6 +8225,7 @@ function Library:CreateWindow(WindowInfo)
     Library.CornerRadius = WindowInfo.CornerRadius
     Library:SetNotifySide(WindowInfo.NotifySide)
     Library.ShowCustomCursor = WindowInfo.ShowCustomCursor
+    Library.MaxNotifications = WindowInfo.MaxNotifications
     Library.Scheme.Font = WindowInfo.Font
     Library.ToggleKeybind = WindowInfo.ToggleKeybind
     Library.GlobalSearch = WindowInfo.GlobalSearch
@@ -11704,6 +11724,7 @@ function Library:Unload()
     table.clear(Library.SpecificCorners)
 
     table.clear(Library.Notifications)
+    table.clear(Library.NotificationQueue)
     table.clear(Library.Dialogues)
     table.clear(Library.DraggableElements)
     table.clear(Library.KeybindToggles)


### PR DESCRIPTION
Firing many notifications fast caused unbounded screen clutter with no way to remove old ones — `Library.Notifications` is an unordered dictionary, so "oldest" was unknowable.

## What changed

- **`Library.NotificationQueue`** — ordered array parallel to the existing dict, so oldest is always `[1]`
- **`Library.MaxNotifications`** (default `10`) — on each `Notify` insert, removes from the front of the queue until under cap. `0` = unlimited. `Persist` notifications are exempt and will remain untouched.
- **`Data:Destroy()`** — removes the entry from the queue on natural expiry so dead references don't block future evictions
- **`Templates.Window` + `CreateWindow`** — wires the setting into the window config so it can be set at the call site:

```lua
Library:CreateWindow({ MaxNotifications = 5 })
```

Unload path clears `NotificationQueue` alongside `Notifications`.
<img width="154" height="1360" alt="Recording 2026-06-28 213959" src="https://github.com/user-attachments/assets/05125ade-aafa-47f1-8ac4-fb4573d122be" />