### PR TITLE
Animations: Groupbox Resize, Rotating Chevron, and KeyPicker Action Menu

### DIFF
--- a/Library.lua
+++ b/Library.lua
@@ -8626,6 +8626,10 @@ function Library:CreateWindow(WindowInfo)
 
     local function SetUICorner(UICorner, Corner, HalfCurrent, HalfValue, Value)
         local Current = UICorner[Corner]
+        if Current.Offset == 0 and Current.Scale == 0 then
+            return
+        end
+
         UICorner[Corner] = Current.Offset == HalfCurrent and HalfValue or Value
     end
 

--- a/Library.lua
+++ b/Library.lua
@@ -216,16 +216,17 @@ local Library = {
 
     WindowAnimationInfo = TweenInfo.new(0.35, Enum.EasingStyle.Quad, Enum.EasingDirection.Out),
     DropdownTransitionInfo = TweenInfo.new(0.18, Enum.EasingStyle.Quad, Enum.EasingDirection.Out),
+    KeyPickerTransitionInfo = TweenInfo.new(0.15, Enum.EasingStyle.Quad, Enum.EasingDirection.Out),
+
     GroupboxTweenInfo = TweenInfo.new(0.2, Enum.EasingStyle.Quad, Enum.EasingDirection.Out),
     RotatingChevronTweenInfo = TweenInfo.new(0.3, Enum.EasingStyle.Back, Enum.EasingDirection.Out),
-    KeyPickerTransitionInfo = TweenInfo.new(0.15, Enum.EasingStyle.Quad, Enum.EasingDirection.Out),
 
     Animations = {
         ToggleWindow = false,
         TabSwitch = false,
-        Dropdown = false,
         Groupbox = false,
-        KeyPicker = false,
+        Dropdown = false,
+        KeyPicker = false
     },
 
     --// States \\--
@@ -400,9 +401,9 @@ local Templates = {
         Animations = {
             ToggleWindow = false,
             TabSwitch = false,
-            Dropdown = false,
             Groupbox = false,
-            KeyPicker = false,
+            Dropdown = false,
+            KeyPicker = false
         },
 
         TabTransitionTime = 0.22,
@@ -490,6 +491,7 @@ local Templates = {
         ValueImages = {},
 
         Multi = false,
+        DragSelect = false,
         MaxVisibleDropdownItems = 8,
 
         Callback = function() end,
@@ -650,6 +652,10 @@ local function IsMouseClickInput(Input: InputObject)
         Input.UserInputType == Enum.UserInputType.MouseButton2 or 
         Input.UserInputType == Enum.UserInputType.MouseButton3
 end
+local function IsMovementInput(Input: InputObject)
+    return (Input.UserInputType == Enum.UserInputType.MouseMovement or Input.UserInputType == Enum.UserInputType.Touch)
+        and Library.IsRobloxFocused
+end
 
 local function GetTableSize(Table: { [any]: any })
     local Size = 0
@@ -660,12 +666,18 @@ local function GetTableSize(Table: { [any]: any })
 
     return Size
 end
-local function StopTween(Tween: TweenBase)
-    if not (Tween and Tween.PlaybackState == Enum.PlaybackState.Playing) then
+local function StopTween(Tween: TweenBase, Destroy: boolean?)
+    if not Tween then
         return
     end
 
-    Tween:Cancel()
+    if Tween.PlaybackState == Enum.PlaybackState.Playing then
+        Tween:Cancel()
+    end
+
+    if Destroy == true then
+        pcall(Tween.Destroy, Tween)
+    end
 end
 local function Trim(Text: string)
     return Text:match("^%s*(.-)%s*$")
@@ -1786,7 +1798,7 @@ function Library:PlayTabAnimation(TabCanvas: CanvasGroup, Showing: boolean, OnCo
 
     local Existing = ActiveTabTweens[TabCanvas]
     if Existing then
-        Existing:Cancel()
+        StopTween(Existing, true)
         ActiveTabTweens[TabCanvas] = nil
     end
 
@@ -2377,7 +2389,7 @@ function Library:AddContextMenu(
     ActiveCallback: (Active: boolean) -> ()?,
     IgnoreCornerRadius: boolean?,
     SpecificCornersOnly: ("top" | "bottom" | "no_left" | "no_top_left")?, -- stupid way of doing this
-    AnimationType: ("Dropdown" | "Groupbox" | "KeyPicker" | "none")?
+    AnimationType: ("Dropdown" | "KeyPicker" | "none")?
 )
     local Menu
     local ParentGui = Holder:FindFirstAncestorOfClass("ScreenGui")
@@ -2476,8 +2488,8 @@ function Library:AddContextMenu(
 
         Size = Size,
 
-        OpenCloseTween = nil,
         AutoSizeY = List == 1,
+        OpenCloseTween = nil,
         Animated = function()
             if not AnimationType or AnimationType == "none" then
                 return false
@@ -2526,7 +2538,7 @@ function Library:AddContextMenu(
         end
 
         if Table.OpenCloseTween then
-            Table.OpenCloseTween:Cancel()
+            StopTween(Table.OpenCloseTween, true)
             Table.OpenCloseTween = nil
         end
 
@@ -2535,6 +2547,7 @@ function Library:AddContextMenu(
             local OpenSize = TargetSize
             if Table.AutoSizeY then
                 local FullHeight = Menu.AbsoluteSize.Y
+
                 Menu.AutomaticSize = Enum.AutomaticSize.None
                 OpenSize = UDim2.new(TargetSize.X.Scale, TargetSize.X.Offset, 0, FullHeight)
             end
@@ -2551,6 +2564,7 @@ function Library:AddContextMenu(
                 end
 
                 if Table.OpenCloseTween == Tween then
+                    StopTween(Table.OpenCloseTween, true)
                     Table.OpenCloseTween = nil
 
                     if Table.AutoSizeY then
@@ -2560,9 +2574,7 @@ function Library:AddContextMenu(
             end))
 
             Tween:Play()
-        end
-
-        if IsAnimated == false then
+        else
             Menu.Size = TargetSize
             Menu.Visible = true
         end
@@ -2604,7 +2616,7 @@ function Library:AddContextMenu(
         end
 
         if Table.OpenCloseTween then
-            Table.OpenCloseTween:Cancel()
+            StopTween(Table.OpenCloseTween, true)
             Table.OpenCloseTween = nil
         end
 
@@ -2626,9 +2638,10 @@ function Library:AddContextMenu(
                 end
 
                 if Table.OpenCloseTween == Tween then
+                    StopTween(Table.OpenCloseTween, true)
                     Table.OpenCloseTween = nil
-                    Menu.Visible = false
 
+                    Menu.Visible = false
                     if Table.AutoSizeY then
                         Menu.AutomaticSize = Enum.AutomaticSize.Y
                     end
@@ -2636,9 +2649,7 @@ function Library:AddContextMenu(
             end))
 
             Tween:Play()
-        end
-
-        if IsAnimated == false then
+        else
             Menu.Visible = false
         end
     end
@@ -2670,7 +2681,7 @@ function Library:AddContextMenu(
         end
 
         if Table.OpenCloseTween then
-            Table.OpenCloseTween:Cancel()
+            StopTween(Table.OpenCloseTween, true)
             Table.OpenCloseTween = nil
         end
 
@@ -3082,14 +3093,12 @@ do
 
         local CancelSlidingTweens = function()
             if SlideForwardTween then
-                SlideForwardTween:Cancel()
-                SlideForwardTween:Destroy()
+                StopTween(SlideForwardTween, true)
                 SlideForwardTween = nil
             end
 
             if SlideBackTween then
-                SlideBackTween:Cancel()
-                SlideBackTween:Destroy()
+                SlideForwardTween(SlideBackTween, true)
                 SlideBackTween = nil
             end
         end
@@ -6214,6 +6223,7 @@ do
             ValueImages = Info.ValueImages,
 
             Multi = Info.Multi,
+            DragSelect = Info.Multi and not Library.IsMobile and Info.DragSelect == true,
 
             SpecialType = Info.SpecialType,
             ExcludeLocalPlayer = Info.ExcludeLocalPlayer,
@@ -6470,9 +6480,54 @@ do
         end
 
         local Buttons = {}
+        local DragSelecting = false
+        local DragStartIndex = nil
+        local DragInitialValues = {}
+        local DragInputEndedConn = nil
+        local DragInputChangedConn = nil
+
+        local function StopDragSelect()
+            DragSelecting = false
+            DragStartIndex = nil
+            table.clear(DragInitialValues)
+
+            if DragInputEndedConn then
+                DragInputEndedConn:Disconnect()
+                DragInputEndedConn = nil
+            end
+
+            if DragInputChangedConn then
+                DragInputChangedConn:Disconnect()
+                DragInputChangedConn = nil
+            end
+        end
+
+        local function UpdateDrag(CurrentIndex)
+            local Min = math.min(DragStartIndex, CurrentIndex)
+            local Max = math.max(DragStartIndex, CurrentIndex)
+
+            for OtherButton, OtherTable in Buttons do
+                local InRange = OtherTable.Index >= Min and OtherTable.Index <= Max
+                local Try = DragInitialValues[OtherTable.Value]
+                if InRange then
+                    Try = not Try
+                end
+
+                if not (Dropdown:GetActiveValues(true) == 1 and not Try and not Info.AllowNull) then
+                    Dropdown.Value[OtherTable.Value] = Try and true or nil
+                end
+
+                OtherTable:UpdateButton()
+            end
+
+            Dropdown:Display()
+        end
+
         function Dropdown:BuildDropdownList()
             local Values = Dropdown.Values
             local DisabledValues = Dropdown.DisabledValues
+
+            StopDragSelect()
 
             for Button, _ in Buttons do
                 if not (Button and Button.Parent) then
@@ -6482,7 +6537,7 @@ do
                 Button.Parent:Destroy()
             end
             table.clear(Buttons)
-            
+
             local Count = 0
             local ProcessedCount = 0
             local TotalLen = GetTableSize(Values) + GetTableSize(DisabledValues)
@@ -6568,10 +6623,14 @@ do
                     end
                 end
 
+                Table.Index = Count
+                Table.Value = Value
+
                 if not IsDisabled then
                     Button.MouseButton1Click:Connect(function()
-                        local Try = not Selected
+                        if DragSelecting then return end
 
+                        local Try = not Selected
                         if not (Dropdown:GetActiveValues(true) == 1 and not Try and not Info.AllowNull) then
                             Selected = Try
                             if Info.Multi then
@@ -6592,6 +6651,54 @@ do
                         Library:SafeCallback(Dropdown.Callback, Dropdown.Value)
                         Library:SafeCallback(Dropdown.Changed, Dropdown.Value)
                     end)
+
+                    if Info.Multi and Dropdown.DragSelect and not Library.IsMobile then
+                        Button.InputBegan:Connect(function(StartInput)
+                            if not IsMouseInput(StartInput) then return end
+
+                            DragSelecting = true
+                            DragStartIndex = Table.Index
+                            table.clear(DragInitialValues)
+
+                            for OtherButton, OtherTable in Buttons do
+                                DragInitialValues[OtherTable.Value] = Dropdown.Value[OtherTable.Value]
+                            end
+
+                            UpdateDrag(Table.Index)
+
+                            if DragInputEndedConn then DragInputEndedConn:Disconnect() end
+                            if DragInputChangedConn then DragInputChangedConn:Disconnect() end
+
+                            DragInputChangedConn = Library:GiveSignal(UserInputService.InputChanged:Connect(function(ChangeInput)
+                                if not IsMovementInput(ChangeInput) and ChangeInput ~= StartInput then
+                                    return
+                                end
+
+                                local Pos = ChangeInput.Position
+                                for OtherButton, OtherTable in Buttons do
+                                    if Library:MouseIsOverFrame(OtherButton, Pos) then
+                                        UpdateDrag(OtherTable.Index)
+                                        break
+                                    end
+                                end
+                            end))
+
+                            DragInputEndedConn = Library:GiveSignal(UserInputService.InputEnded:Connect(function(EndInput)
+                                if EndInput ~= StartInput and not (IsMouseInput(EndInput) and EndInput.UserInputType == StartInput.UserInputType) then
+                                    return
+                                end
+
+                                Library:UpdateDependencyBoxes()
+                                Library:SafeCallback(Dropdown.Callback, Dropdown.Value)
+                                Library:SafeCallback(Dropdown.Changed, Dropdown.Value)
+
+                                StopDragSelect()
+                            end))
+
+                            table.insert(Dropdown.Connections, DragInputEndedConn)
+                            table.insert(Dropdown.Connections, DragInputChangedConn)
+                        end)
+                    end
                 end
 
                 Table:UpdateButton()
@@ -6722,6 +6829,15 @@ do
             Label.Visible = not not Text
         end
 
+        function Dropdown:SetDragSelect(Value: boolean)
+            if not Info.Multi or Library.IsMobile then 
+                Value = false
+            end
+
+            Dropdown.DragSelect = Value == true
+            Dropdown:BuildDropdownList()
+        end
+
         local ToggleDropdown = function()
             if Dropdown.Disabled then
                 return
@@ -6789,6 +6905,8 @@ do
 
         function Dropdown:Destroy()
             Dropdown.Destroyed = true
+
+            StopDragSelect()
 
             if Dropdown.Connections then
                 for _, Connection in Dropdown.Connections do
@@ -7561,7 +7679,7 @@ do
             Container = DepboxContainer,
 
             Elements = {},
-            DependencyBoxes = {},
+            DependencyBoxes = {}
         }
 
         function Depbox:Resize()
@@ -9633,36 +9751,36 @@ function Library:CreateWindow(WindowInfo)
 
                 Tab = Tab,
                 DependencyBoxes = {},
-                Elements = {},
-                ResizeTween = nil,
-                ChevronTween = nil
+                Elements = {}
             }
 
-            function Groupbox:Resize()
-                local TargetSize = UDim2.new(1, 0, 0, if Groupbox.Collapsed then 34 else (GroupboxList.AbsoluteContentSize.Y / Library.DPIScale) + 49)
-                GroupboxLine.Visible = not Groupbox.Collapsed
+            local ResizeTween
+            local CollapseArrowTween
 
-                if Groupbox.ResizeTween then
-                    Groupbox.ResizeTween:Cancel()
-                    Groupbox.ResizeTween = nil
+            function Groupbox:Resize()
+                if ResizeTween then
+                    StopTween(ResizeTween, true)
+                    ResizeTween = nil
                 end
 
+                local TargetSize = UDim2.new(1, 0, 0, if Groupbox.Collapsed then 34 else (GroupboxList.AbsoluteContentSize.Y / Library.DPIScale) + 49)
+
+                GroupboxLine.Visible = not Groupbox.Collapsed
                 if Library.Animations and Library.Animations.Groupbox then
-                    local Info = Library.GroupboxTweenInfo
-                        or TweenInfo.new(0.2, Enum.EasingStyle.Quad, Enum.EasingDirection.Out)
+                    local TweenInfo = Library.GroupboxTweenInfo or TweenInfo.new(0.2, Enum.EasingStyle.Quad, Enum.EasingDirection.Out)
+                    local Tween = TweenService:Create(GroupboxHolder, TweenInfo, { Size = TargetSize })
+                    ResizeTween = Tween
 
-                    local Tween = TweenService:Create(GroupboxHolder, Info, { Size = TargetSize })
-                    Groupbox.ResizeTween = Tween
-
-                    local Connection
-                    Connection = Tween.Completed:Connect(function()
+                    local Connection; Connection = Library:GiveSignal(Tween.Completed:Once(function()
                         if Connection then
                             Connection:Disconnect()
                         end
-                        if Groupbox.ResizeTween == Tween then
-                            Groupbox.ResizeTween = nil
+
+                        if ResizeTween == Tween then
+                            StopTween(ResizeTween, true)
+                            ResizeTween = nil
                         end
-                    end)
+                    end))
 
                     Tween:Play()
                 else
@@ -9674,31 +9792,29 @@ function Library:CreateWindow(WindowInfo)
                 if Info.DisableCollapsing == true then return end
                 Groupbox.Collapsed = Collapsed
 
-                GroupboxContainer.Visible = not Collapsed
+                if CollapseArrowTween then
+                    StopTween(CollapseArrowTween, true)
+                    CollapseArrowTween = nil
+                end
 
                 local TargetRotation = if Collapsed then 0 else 180
 
-                if Groupbox.ChevronTween then
-                    Groupbox.ChevronTween:Cancel()
-                    Groupbox.ChevronTween = nil
-                end
-
+                GroupboxContainer.Visible = not Collapsed
                 if Library.Animations and Library.Animations.Groupbox then
-                    local ChevronInfo = Library.GroupboxTweenInfo
-                        or TweenInfo.new(0.3, Enum.EasingStyle.Back, Enum.EasingDirection.Out)
+                    local TweenInfo = Library.GroupboxTweenInfo or TweenInfo.new(0.3, Enum.EasingStyle.Back, Enum.EasingDirection.Out)
+                    local Tween = TweenService:Create(GroupboxCollapseArrow, TweenInfo, { Rotation = TargetRotation })
+                    CollapseArrowTween = Tween
 
-                    local Tween = TweenService:Create(GroupboxCollapseArrow, ChevronInfo, { Rotation = TargetRotation })
-                    Groupbox.ChevronTween = Tween
-
-                    local Connection
-                    Connection = Tween.Completed:Connect(function()
+                    local Connection; Connection = Library:GiveSignal(Tween.Completed:Connect(function()
                         if Connection then
                             Connection:Disconnect()
                         end
-                        if Groupbox.ChevronTween == Tween then
-                            Groupbox.ChevronTween = nil
+
+                        if CollapseArrowTween == Tween then
+                            StopTween(CollapseArrowTween, true)
+                            CollapseArrowTween = nil
                         end
-                    end)
+                    end))
 
                     Tween:Play()
                 else
@@ -9716,14 +9832,14 @@ function Library:CreateWindow(WindowInfo)
             function Groupbox:Destroy()
                 Groupbox.Destroyed = true
 
-                if Groupbox.ResizeTween then
-                    Groupbox.ResizeTween:Cancel()
-                    Groupbox.ResizeTween = nil
+                if ResizeTween then
+                    StopTween(ResizeTween, true)
+                    ResizeTween = nil
                 end
 
-                if Groupbox.ChevronTween then
-                    Groupbox.ChevronTween:Cancel()
-                    Groupbox.ChevronTween = nil
+                if CollapseArrowTween then
+                    StopTween(CollapseArrowTween, true)
+                    CollapseArrowTween = nil
                 end
 
                 if Groupbox.Connections then
@@ -11477,8 +11593,8 @@ function Library:CreateLoading(LoadingInfo)
 
     function Loading:SetLoadingIconTweenTime(TweenTime)
         if RotationTween then
-            RotationTween:Cancel()
-            RotationTween:Destroy()
+            StopTween(RotationTween, true)
+            RotationTween = nil
         end
 
         if TweenTime > 0 then
@@ -11683,7 +11799,8 @@ function Library:CreateLoading(LoadingInfo)
     --// Destroy/Continue \\--
     function Loading:Destroy()
         if RotationTween then
-            RotationTween:Cancel()
+            StopTween(RotationTween, true)
+            RotationTween = nil
         end
 
         ScreenGui:Destroy()

--- a/Library.lua
+++ b/Library.lua
@@ -216,11 +216,16 @@ local Library = {
 
     WindowAnimationInfo = TweenInfo.new(0.35, Enum.EasingStyle.Quad, Enum.EasingDirection.Out),
     DropdownTransitionInfo = TweenInfo.new(0.18, Enum.EasingStyle.Quad, Enum.EasingDirection.Out),
+    GroupboxTweenInfo = TweenInfo.new(0.2, Enum.EasingStyle.Quad, Enum.EasingDirection.Out),
+    RotatingChevronTweenInfo = TweenInfo.new(0.3, Enum.EasingStyle.Back, Enum.EasingDirection.Out),
+    KeyPickerTransitionInfo = TweenInfo.new(0.15, Enum.EasingStyle.Quad, Enum.EasingDirection.Out),
 
     Animations = {
         ToggleWindow = false,
         TabSwitch = false,
-        Dropdown = false
+        Dropdown = false,
+        Groupbox = false,
+        KeyPicker = false,
     },
 
     --// States \\--
@@ -395,7 +400,9 @@ local Templates = {
         Animations = {
             ToggleWindow = false,
             TabSwitch = false,
-            Dropdown = false
+            Dropdown = false,
+            Groupbox = false,
+            KeyPicker = false,
         },
 
         TabTransitionTime = 0.22,
@@ -2370,7 +2377,7 @@ function Library:AddContextMenu(
     ActiveCallback: (Active: boolean) -> ()?,
     IgnoreCornerRadius: boolean?,
     SpecificCornersOnly: ("top" | "bottom" | "no_left" | "no_top_left")?, -- stupid way of doing this
-    AnimationType: ("Dropdown" | "none")?
+    AnimationType: ("Dropdown" | "Groupbox" | "KeyPicker" | "none")?
 )
     local Menu
     local ParentGui = Holder:FindFirstAncestorOfClass("ScreenGui")
@@ -2470,6 +2477,7 @@ function Library:AddContextMenu(
         Size = Size,
 
         OpenCloseTween = nil,
+        AutoSizeY = List == 1,
         Animated = function()
             if not AnimationType or AnimationType == "none" then
                 return false
@@ -2524,27 +2532,34 @@ function Library:AddContextMenu(
 
         local IsAnimated, TweenInfo = Table.Animated()
         if IsAnimated == true then
-            if AnimationType == "Dropdown" then
-                Menu.Size = UDim2.new(TargetSize.X.Scale, TargetSize.X.Offset, 0, 0)
-                Menu.Visible = true
-
-                local Tween = TweenService:Create(Menu, TweenInfo, { Size = TargetSize })
-                Table.OpenCloseTween = Tween
-
-                local Connection; Connection = Library:GiveSignal(Tween.Completed:Once(function()
-                    if Connection then
-                        Connection:Disconnect()
-                    end
-
-                    if Table.OpenCloseTween == Tween then
-                        Table.OpenCloseTween = nil
-                    end
-                end))
-
-                Tween:Play()
-            else
-                IsAnimated = false
+            local OpenSize = TargetSize
+            if Table.AutoSizeY then
+                local FullHeight = Menu.AbsoluteSize.Y
+                Menu.AutomaticSize = Enum.AutomaticSize.None
+                OpenSize = UDim2.new(TargetSize.X.Scale, TargetSize.X.Offset, 0, FullHeight)
             end
+
+            Menu.Size = UDim2.new(OpenSize.X.Scale, OpenSize.X.Offset, 0, 0)
+            Menu.Visible = true
+
+            local Tween = TweenService:Create(Menu, TweenInfo, { Size = OpenSize })
+            Table.OpenCloseTween = Tween
+
+            local Connection; Connection = Library:GiveSignal(Tween.Completed:Once(function()
+                if Connection then
+                    Connection:Disconnect()
+                end
+
+                if Table.OpenCloseTween == Tween then
+                    Table.OpenCloseTween = nil
+
+                    if Table.AutoSizeY then
+                        Menu.AutomaticSize = Enum.AutomaticSize.Y
+                    end
+                end
+            end))
+
+            Tween:Play()
         end
 
         if IsAnimated == false then
@@ -2595,29 +2610,32 @@ function Library:AddContextMenu(
 
         local IsAnimated, TweenInfo = Table.Animated()
         if IsAnimated == true then
-            if AnimationType == "Dropdown" then
-                local CurrentSize = Menu.Size
-                local CollapsedSize = UDim2.new(CurrentSize.X.Scale, CurrentSize.X.Offset, 0, 0)
-
-                local Tween = TweenService:Create(Menu, TweenInfo, { Size = CollapsedSize })
-                Table.OpenCloseTween = Tween
-
-                local Connection; Connection = Library:GiveSignal(Tween.Completed:Once(function(PlaybackState)
-                    if Connection then
-                        Connection:Disconnect()
-                    end
-
-                    if Table.OpenCloseTween == Tween then
-                        Table.OpenCloseTween = nil
-                    end
-
-                    Menu.Visible = false
-                end))
-
-                Tween:Play()
-            else
-                IsAnimated = false
+            if Table.AutoSizeY then
+                Menu.AutomaticSize = Enum.AutomaticSize.None
             end
+
+            local CurrentSize = Menu.Size
+            local CollapsedSize = UDim2.new(CurrentSize.X.Scale, CurrentSize.X.Offset, 0, 0)
+
+            local Tween = TweenService:Create(Menu, TweenInfo, { Size = CollapsedSize })
+            Table.OpenCloseTween = Tween
+
+            local Connection; Connection = Library:GiveSignal(Tween.Completed:Once(function(PlaybackState)
+                if Connection then
+                    Connection:Disconnect()
+                end
+
+                if Table.OpenCloseTween == Tween then
+                    Table.OpenCloseTween = nil
+                    Menu.Visible = false
+
+                    if Table.AutoSizeY then
+                        Menu.AutomaticSize = Enum.AutomaticSize.Y
+                    end
+                end
+            end))
+
+            Tween:Play()
         end
 
         if IsAnimated == false then
@@ -3232,7 +3250,7 @@ do
         end, 1, function(Active: boolean)
             PickerCorner.TopRightRadius = Active and UDim.new(0, 0) or UDim.new(0, Library.CornerRadius / 2)
             PickerCorner.BottomRightRadius = Active and UDim.new(0, 0) or UDim.new(0, Library.CornerRadius / 2)
-        end, false, if TotalModeButtons == 1 then "no_left" else "no_top_left")
+        end, false, if TotalModeButtons == 1 then "no_left" else "no_top_left", "KeyPicker")
         KeyPicker.Menu = MenuTable
 
         for Index, Mode in Info.Modes do
@@ -8608,10 +8626,6 @@ function Library:CreateWindow(WindowInfo)
 
     local function SetUICorner(UICorner, Corner, HalfCurrent, HalfValue, Value)
         local Current = UICorner[Corner]
-        if Current.Offset == 0 and Current.Scale == 0 then
-            return
-        end
-
         UICorner[Corner] = Current.Offset == HalfCurrent and HalfValue or Value
     end
 
@@ -9615,12 +9629,41 @@ function Library:CreateWindow(WindowInfo)
 
                 Tab = Tab,
                 DependencyBoxes = {},
-                Elements = {}
+                Elements = {},
+                ResizeTween = nil,
+                ChevronTween = nil
             }
 
             function Groupbox:Resize()
-                GroupboxHolder.Size = UDim2.new(1, 0, 0, if Groupbox.Collapsed then 34 else (GroupboxList.AbsoluteContentSize.Y / Library.DPIScale) + 49)
+                local TargetSize = UDim2.new(1, 0, 0, if Groupbox.Collapsed then 34 else (GroupboxList.AbsoluteContentSize.Y / Library.DPIScale) + 49)
                 GroupboxLine.Visible = not Groupbox.Collapsed
+
+                if Groupbox.ResizeTween then
+                    Groupbox.ResizeTween:Cancel()
+                    Groupbox.ResizeTween = nil
+                end
+
+                if Library.Animations and Library.Animations.Groupbox then
+                    local Info = Library.GroupboxTweenInfo
+                        or TweenInfo.new(0.2, Enum.EasingStyle.Quad, Enum.EasingDirection.Out)
+
+                    local Tween = TweenService:Create(GroupboxHolder, Info, { Size = TargetSize })
+                    Groupbox.ResizeTween = Tween
+
+                    local Connection
+                    Connection = Tween.Completed:Connect(function()
+                        if Connection then
+                            Connection:Disconnect()
+                        end
+                        if Groupbox.ResizeTween == Tween then
+                            Groupbox.ResizeTween = nil
+                        end
+                    end)
+
+                    Tween:Play()
+                else
+                    GroupboxHolder.Size = TargetSize
+                end
             end
 
             function Groupbox:SetCollapsed(Collapsed: boolean)
@@ -9628,7 +9671,36 @@ function Library:CreateWindow(WindowInfo)
                 Groupbox.Collapsed = Collapsed
 
                 GroupboxContainer.Visible = not Collapsed
-                GroupboxCollapseArrow.Rotation = if Collapsed then 0 else 180
+
+                local TargetRotation = if Collapsed then 0 else 180
+
+                if Groupbox.ChevronTween then
+                    Groupbox.ChevronTween:Cancel()
+                    Groupbox.ChevronTween = nil
+                end
+
+                if Library.Animations and Library.Animations.Groupbox then
+                    local ChevronInfo = Library.GroupboxTweenInfo
+                        or TweenInfo.new(0.3, Enum.EasingStyle.Back, Enum.EasingDirection.Out)
+
+                    local Tween = TweenService:Create(GroupboxCollapseArrow, ChevronInfo, { Rotation = TargetRotation })
+                    Groupbox.ChevronTween = Tween
+
+                    local Connection
+                    Connection = Tween.Completed:Connect(function()
+                        if Connection then
+                            Connection:Disconnect()
+                        end
+                        if Groupbox.ChevronTween == Tween then
+                            Groupbox.ChevronTween = nil
+                        end
+                    end)
+
+                    Tween:Play()
+                else
+                    GroupboxCollapseArrow.Rotation = TargetRotation
+                end
+
                 Groupbox:Resize()
             end
 
@@ -9639,6 +9711,16 @@ function Library:CreateWindow(WindowInfo)
 
             function Groupbox:Destroy()
                 Groupbox.Destroyed = true
+
+                if Groupbox.ResizeTween then
+                    Groupbox.ResizeTween:Cancel()
+                    Groupbox.ResizeTween = nil
+                end
+
+                if Groupbox.ChevronTween then
+                    Groupbox.ChevronTween:Cancel()
+                    Groupbox.ChevronTween = nil
+                end
 
                 if Groupbox.Connections then
                     for _, Connection in Groupbox.Connections do


### PR DESCRIPTION
i finally got around to finishing this PR after having many, many skill issues :zap: 

**What changed**
- `Groupbox:Resize()` now tweens `GroupboxHolder.Size` from its old size to the new size instead of snapping instantly.
- `Groupbox:SetCollapsed()` now tweens the collapse arrow's `Rotation` (0°/180°) instead of snapping it.
- Both gate behind a new flag: `Library.Animations.Groupbox` (default `false`, opt-in like the existing `Dropdown`/`ToggleWindow` animations).
- In-progress tweens are tracked (`Groupbox.ResizeTween` / `Groupbox.ChevronTween`) and cancelled on overlapping toggles or `Destroy()` to avoid stacked/competing tweens.

**Why**
- Groupboxes and their collapse arrows currently resize/rotate in a single frame, which feels abrupt compared to the rest of the animated UI. Tweening these brings them in line with the other motion work.

## Groupbox Resize & Rotating Chevron
(slightly outdated as the chevron tween has been simplified slightly from when this gif was recorded but i can't be asked to redo this gif again)
<img width="800" height="662" alt="Groupbox" src="https://github.com/user-attachments/assets/b9e337e2-20b8-452e-9d95-8124ed4a22b7" />

## Extra: KeyPicker Action Menu
(this isn't mentioned in the "What changed" section. i just bored and just decided one day to add this)
<img width="800" height="652" alt="Keypicker Action Menu" src="https://github.com/user-attachments/assets/98b2f0d4-c6d6-44ad-9546-798f56831355" />