### PR TITLE
ColorPicker: copy/paste buttons + resizable menu

### DIFF
--- a/Library.lua
+++ b/Library.lua
@@ -549,6 +549,8 @@ local Templates = {
     ColorPicker = {
         Default = Color3.new(1, 1, 1),
 
+        Resizable = true,
+
         Callback = function() end,
         Changed = function() end,
     },
@@ -4026,6 +4028,133 @@ do
             })
         end
 
+        --// Resizing \\--
+        local ResizeGrabber
+        if Info.Resizable then
+            local BaseSquareSize = 200
+            local BaseBarWidth = 16
+            local BasePadding = 6
+            local MinSquareSize = 140
+            local MaxSquareSize = 320
+
+            ColorPicker.SquareSize = BaseSquareSize
+
+            local function GetBarWidth(SquareSize)
+                return math.clamp(math.floor((SquareSize / BaseSquareSize) * BaseBarWidth + 0.5), 12, 24)
+            end
+
+            local function GetContentWidth(SquareSize)
+                local BarWidth = GetBarWidth(SquareSize)
+                local Width = SquareSize + BarWidth + BasePadding
+                if Info.Transparency then
+                    Width += (BarWidth + BasePadding)
+                end
+
+                return Width + 12
+            end
+
+            local FixedVerticalOverhead = 90
+
+            local function ClampToViewport(NewSquareSize)
+                local Camera = workspace.CurrentCamera
+                if not Camera then
+                    return NewSquareSize
+                end
+
+                local ViewportSize = Camera.ViewportSize
+                local ScreenMargin = 12
+
+                local MaxWidth = ViewportSize.X - ColorMenu.Menu.AbsolutePosition.X - ScreenMargin
+                local MaxHeight = ViewportSize.Y - ColorMenu.Menu.AbsolutePosition.Y - ScreenMargin - FixedVerticalOverhead
+
+                while NewSquareSize > MinSquareSize
+                    and (GetContentWidth(NewSquareSize) > MaxWidth or NewSquareSize > MaxHeight) do
+                    NewSquareSize -= 4
+                end
+
+                return NewSquareSize
+            end
+
+            local function UpdateColorMenuSize(NewSquareSize)
+                NewSquareSize = math.clamp(math.floor(NewSquareSize + 0.5), MinSquareSize, MaxSquareSize)
+                NewSquareSize = ClampToViewport(NewSquareSize)
+
+                if NewSquareSize == ColorPicker.SquareSize then
+                    return
+                end
+
+                local BarWidth = GetBarWidth(NewSquareSize)
+                local CursorSize = math.clamp(math.floor((NewSquareSize / BaseSquareSize) * 6 + 0.5), 4, 10)
+
+                ColorHolder.Size = UDim2.new(1, 0, 0, NewSquareSize)
+                SatVipMap.Size = UDim2.fromOffset(NewSquareSize, NewSquareSize)
+                SatVibCursor.Size = UDim2.fromOffset(CursorSize, CursorSize)
+                HueSelector.Size = UDim2.new(0, BarWidth, 0, NewSquareSize)
+
+                if TransparencySelector then
+                    TransparencySelector.Size = UDim2.new(0, BarWidth, 0, NewSquareSize)
+                end
+
+                ColorPicker.SquareSize = NewSquareSize
+                ColorMenu:SetSize(UDim2.new(0, GetContentWidth(NewSquareSize), 0, 0))
+            end
+
+            local IconSize = 12
+            local GrabberSize = Library.IsMobile and 28 or 16
+            local GrabberInset = 2
+
+            ResizeGrabber = New("TextButton", {
+                AnchorPoint = Vector2.new(1, 1),
+                BackgroundTransparency = 1,
+                Size = UDim2.fromOffset(GrabberSize, GrabberSize),
+                Text = "",
+                Visible = false,
+                ZIndex = ColorMenu.Menu.ZIndex + 1,
+                Parent = ColorMenu.Menu.Parent,
+            })
+            New("ImageLabel", {
+                AnchorPoint = Vector2.new(1, 1),
+                BackgroundTransparency = 1,
+                Image = ResizeIcon and ResizeIcon.Url or "",
+                ImageColor3 = "FontColor",
+                ImageRectOffset = ResizeIcon and ResizeIcon.ImageRectOffset or Vector2.zero,
+                ImageRectSize = ResizeIcon and ResizeIcon.ImageRectSize or Vector2.zero,
+                ImageTransparency = 0.35,
+                Position = UDim2.fromScale(1, 1),
+                Size = UDim2.fromOffset(IconSize, IconSize),
+                Parent = ResizeGrabber,
+            })
+
+            local function UpdateGrabberPosition()
+                ResizeGrabber.Position = UDim2.fromOffset(
+                    ColorMenu.Menu.AbsolutePosition.X + ColorMenu.Menu.AbsoluteSize.X - GrabberInset,
+                    ColorMenu.Menu.AbsolutePosition.Y + ColorMenu.Menu.AbsoluteSize.Y - GrabberInset
+                )
+                ResizeGrabber.Visible = ColorMenu.Menu.Visible
+            end
+
+            table.insert(ColorPicker.Connections, ColorMenu.Menu:GetPropertyChangedSignal("AbsolutePosition"):Connect(UpdateGrabberPosition))
+            table.insert(ColorPicker.Connections, ColorMenu.Menu:GetPropertyChangedSignal("AbsoluteSize"):Connect(UpdateGrabberPosition))
+            table.insert(ColorPicker.Connections, ColorMenu.Menu:GetPropertyChangedSignal("Visible"):Connect(UpdateGrabberPosition))
+
+            table.insert(ColorPicker.Connections, ResizeGrabber.InputBegan:Connect(function(Input: InputObject)
+                Library.CantDragForced = true
+                local StartMouse = Vector2.new(Mouse.X, Mouse.Y)
+                local StartSquareSize = ColorPicker.SquareSize
+
+                while IsDragInput(Input) and not ColorPicker.Destroyed do
+                    local Delta = Vector2.new(Mouse.X, Mouse.Y) - StartMouse
+                    UpdateColorMenuSize(StartSquareSize + math.max(Delta.X, Delta.Y))
+
+                    RunService.RenderStepped:Wait()
+                end
+
+                Library.CantDragForced = false
+            end))
+
+            UpdateGrabberPosition()
+        end
+
         local InfoHolder = New("Frame", {
             BackgroundTransparency = 1,
             Size = UDim2.new(1, 0, 0, 20),
@@ -4113,6 +4242,10 @@ do
 
             ColorPicker.SetValueRGB = function(...) end --// make luau lsp shut up
             CreateButton("Paste color", function()
+                if not Library.CopiedColor then
+                    return
+                end
+
                 ColorPicker:SetValueRGB(Library.CopiedColor[1], Library.CopiedColor[2])
             end)
 
@@ -4130,6 +4263,69 @@ do
                 end)
             end
         end
+
+        --// Copy/Paste Buttons \\--
+        local ActionHolder = New("Frame", {
+            BackgroundTransparency = 1,
+            Size = UDim2.new(1, 0, 0, 20),
+            Parent = ColorMenu.Menu,
+        })
+        New("UIListLayout", {
+            FillDirection = Enum.FillDirection.Horizontal,
+            HorizontalFlex = Enum.UIFlexAlignment.Fill,
+            Padding = UDim.new(0, 8),
+            Parent = ActionHolder,
+        })
+
+        local CopyColorButton = New("TextButton", {
+            BackgroundColor3 = "MainColor",
+            Size = UDim2.fromScale(1, 1),
+            Text = "Copy color",
+            TextSize = 14,
+            Parent = ActionHolder,
+        })
+        New("UIStroke", {
+            Color = "OutlineColor",
+            Parent = CopyColorButton,
+        })
+        table.insert(
+            Library.Corners,
+            New("UICorner", {
+                CornerRadius = UDim.new(0, Library.CornerRadius / 2),
+                Parent = CopyColorButton,
+            })
+        )
+
+        local PasteColorButton = New("TextButton", {
+            BackgroundColor3 = "MainColor",
+            Size = UDim2.fromScale(1, 1),
+            Text = "Paste color",
+            TextSize = 14,
+            Parent = ActionHolder,
+        })
+        New("UIStroke", {
+            Color = "OutlineColor",
+            Parent = PasteColorButton,
+        })
+        table.insert(
+            Library.Corners,
+            New("UICorner", {
+                CornerRadius = UDim.new(0, Library.CornerRadius / 2),
+                Parent = PasteColorButton,
+            })
+        )
+
+        table.insert(ColorPicker.Connections, CopyColorButton.MouseButton1Click:Connect(function()
+            Library.CopiedColor = { ColorPicker.Value, ColorPicker.Transparency }
+        end))
+
+        table.insert(ColorPicker.Connections, PasteColorButton.MouseButton1Click:Connect(function()
+            if not Library.CopiedColor then
+                return
+            end
+
+            ColorPicker:SetValueRGB(Library.CopiedColor[1], Library.CopiedColor[2])
+        end))
 
         --// End \\--
         function ColorPicker:SetHSVFromRGB(Color)
@@ -4302,6 +4498,10 @@ do
 
             if ColorMenu then 
                 ColorMenu:Destroy() 
+            end
+
+            if ResizeGrabber then
+                ResizeGrabber:Destroy()
             end
 
             if ContextMenu then 

--- a/Library.lua
+++ b/Library.lua
@@ -4315,16 +4315,69 @@ do
             })
         )
 
+        local CopyColorOriginalText = CopyColorButton.Text
+        local PasteColorOriginalText = PasteColorButton.Text
+        local CopyColorResetId = 0
+        local PasteColorResetId = 0
+
+        table.insert(ColorPicker.Connections, CopyColorButton.MouseEnter:Connect(function()
+            TweenService:Create(CopyColorButton, Library.TweenInfo, {
+                BackgroundColor3 = Library:GetBetterColor(Library.Scheme.MainColor, 10),
+            }):Play()
+        end))
+
+        table.insert(ColorPicker.Connections, CopyColorButton.MouseLeave:Connect(function()
+            TweenService:Create(CopyColorButton, Library.TweenInfo, {
+                BackgroundColor3 = Library.Scheme.MainColor,
+            }):Play()
+        end))
+
+        table.insert(ColorPicker.Connections, PasteColorButton.MouseEnter:Connect(function()
+            TweenService:Create(PasteColorButton, Library.TweenInfo, {
+                BackgroundColor3 = Library:GetBetterColor(Library.Scheme.MainColor, 10),
+            }):Play()
+        end))
+
+        table.insert(ColorPicker.Connections, PasteColorButton.MouseLeave:Connect(function()
+            TweenService:Create(PasteColorButton, Library.TweenInfo, {
+                BackgroundColor3 = Library.Scheme.MainColor,
+            }):Play()
+        end))
+
         table.insert(ColorPicker.Connections, CopyColorButton.MouseButton1Click:Connect(function()
             Library.CopiedColor = { ColorPicker.Value, ColorPicker.Transparency }
+
+            CopyColorResetId += 1
+            local ThisResetId = CopyColorResetId
+            CopyColorButton.Text = "Copied color"
+
+            task.delay(1, function()
+                if ColorPicker.Destroyed or ThisResetId ~= CopyColorResetId then
+                    return
+                end
+
+                CopyColorButton.Text = CopyColorOriginalText
+            end)
         end))
 
         table.insert(ColorPicker.Connections, PasteColorButton.MouseButton1Click:Connect(function()
+            PasteColorResetId += 1
+            local ThisResetId = PasteColorResetId
+
             if not Library.CopiedColor then
-                return
+                PasteColorButton.Text = "Nothing to paste"
+            else
+                ColorPicker:SetValueRGB(Library.CopiedColor[1], Library.CopiedColor[2])
+                PasteColorButton.Text = "Pasted color"
             end
 
-            ColorPicker:SetValueRGB(Library.CopiedColor[1], Library.CopiedColor[2])
+            task.delay(1, function()
+                if ColorPicker.Destroyed or ThisResetId ~= PasteColorResetId then
+                    return
+                end
+
+                PasteColorButton.Text = PasteColorOriginalText
+            end)
         end))
 
         --// End \\--

--- a/Library.lua
+++ b/Library.lua
@@ -3966,16 +3966,90 @@ do
                 ColorPickerCorner.BottomRightRadius = Active and UDim.new(0, 0) or UDim.new(0, Library.CornerRadius / 2)
                 ColorPickerCorner.BottomLeftRadius = Active and UDim.new(0, 0) or UDim.new(0, Library.CornerRadius / 2)
             end, false, "no_top_left")
-        ColorMenu.List.Padding = UDim.new(0, 8)
+        ColorMenu.List.Padding = UDim.new(0, 0)
         ColorPicker.ColorMenu = ColorMenu
 
+        --// Content Holder \\--
+        -- Everything above the footer lives in here, so the footer below can
+        -- span the full width/edge of the menu (matching the main window footer).
+        local ContentHolder = New("Frame", {
+            AutomaticSize = Enum.AutomaticSize.Y,
+            BackgroundTransparency = 1,
+            Size = UDim2.fromScale(1, 0),
+            Parent = ColorMenu.Menu,
+        })
+        New("UIListLayout", {
+            Padding = UDim.new(0, 8),
+            Parent = ContentHolder,
+        })
         New("UIPadding", {
             PaddingBottom = UDim.new(0, 6),
             PaddingLeft = UDim.new(0, 6),
             PaddingRight = UDim.new(0, 6),
             PaddingTop = UDim.new(0, 6),
+            Parent = ContentHolder,
+        })
+
+        --// Footer \\--
+        -- Copied from the main window's footer: a tinted bar under a divider
+        -- line, showing the current hex/rgb and (if resizable) hosting the
+        -- resize grabber, so the grabber no longer overlaps the paste button.
+        local FooterHeight = Library.IsMobile and 30 or 22
+
+        local FooterBackground = New("Frame", {
+            BackgroundColor3 = function()
+                return Library:GetBetterColor(Library.Scheme.BackgroundColor, 4)
+            end,
+            Size = UDim2.new(1, 0, 0, FooterHeight),
             Parent = ColorMenu.Menu,
         })
+        table.insert(
+            Library.SpecificCorners,
+            New("UICorner", {
+                TopLeftRadius = UDim.new(0, 0),
+                TopRightRadius = UDim.new(0, 0),
+                BottomLeftRadius = UDim.new(0, Library.CornerRadius / 2),
+                BottomRightRadius = UDim.new(0, Library.CornerRadius / 2),
+                Parent = FooterBackground,
+            })
+        )
+        Library:MakeLine(FooterBackground, {
+            Position = UDim2.fromScale(0, 0),
+            Size = UDim2.new(1, 0, 0, 1),
+        })
+
+        local FooterBar = New("Frame", {
+            BackgroundTransparency = 1,
+            Size = UDim2.fromScale(1, 1),
+            Parent = FooterBackground,
+        })
+        New("UIPadding", {
+            PaddingLeft = UDim.new(0, 6),
+            PaddingRight = UDim.new(0, Info.Resizable and (FooterHeight + 4) or 6),
+            Parent = FooterBar,
+        })
+
+        local FooterInfoLabel = New("TextLabel", {
+            BackgroundTransparency = 1,
+            Size = UDim2.fromScale(1, 1),
+            Text = "",
+            TextSize = 14,
+            TextTransparency = 0.5,
+            TextTruncate = Enum.TextTruncate.AtEnd,
+            TextXAlignment = Enum.TextXAlignment.Center,
+            Parent = FooterBar,
+        })
+
+        local function RefreshFooterInfo()
+            FooterInfoLabel.Text = string.format(
+                "#%s  ·  %d, %d, %d",
+                ColorPicker.Value:ToHex(),
+                math.floor(ColorPicker.Value.R * 255),
+                math.floor(ColorPicker.Value.G * 255),
+                math.floor(ColorPicker.Value.B * 255)
+            )
+        end
+        RefreshFooterInfo()
 
         if typeof(ColorPicker.Title) == "string" then
             New("TextLabel", {
@@ -3984,14 +4058,14 @@ do
                 Text = ColorPicker.Title,
                 TextSize = 14,
                 TextXAlignment = Enum.TextXAlignment.Left,
-                Parent = ColorMenu.Menu,
+                Parent = ContentHolder,
             })
         end
 
         local ColorHolder = New("Frame", {
             BackgroundTransparency = 1,
             Size = UDim2.new(1, 0, 0, 200),
-            Parent = ColorMenu.Menu,
+            Parent = ContentHolder,
         })
         New("UIListLayout", {
             FillDirection = Enum.FillDirection.Horizontal,
@@ -4153,41 +4227,32 @@ do
 
             local IconSize = 12
             local GrabberSize = Library.IsMobile and 28 or 16
-            local GrabberInset = 2
 
             ResizeGrabber = New("TextButton", {
                 AnchorPoint = Vector2.new(1, 1),
                 BackgroundTransparency = 1,
+                Position = UDim2.new(1, 0, 1, 0),
                 Size = UDim2.fromOffset(GrabberSize, GrabberSize),
                 Text = "",
-                Visible = false,
-                ZIndex = ColorMenu.Menu.ZIndex + 1,
-                Parent = ColorMenu.Menu.Parent,
+                -- Parented to FooterBackground (not FooterBar) so this Scale-based
+                -- position resolves against the footer's full bounds rather than
+                -- FooterBar's padded content area, which would otherwise pull it
+                -- inward by PaddingRight and land it near the text instead of the
+                -- true bottom-right corner.
+                Parent = FooterBackground,
             })
             New("ImageLabel", {
-                AnchorPoint = Vector2.new(1, 1),
+                AnchorPoint = Vector2.new(0.5, 0.5),
                 BackgroundTransparency = 1,
                 Image = ResizeIcon and ResizeIcon.Url or "",
                 ImageColor3 = "FontColor",
                 ImageRectOffset = ResizeIcon and ResizeIcon.ImageRectOffset or Vector2.zero,
                 ImageRectSize = ResizeIcon and ResizeIcon.ImageRectSize or Vector2.zero,
                 ImageTransparency = 0.35,
-                Position = UDim2.fromScale(1, 1),
+                Position = UDim2.fromScale(0.5, 0.5),
                 Size = UDim2.fromOffset(IconSize, IconSize),
                 Parent = ResizeGrabber,
             })
-
-            local function UpdateGrabberPosition()
-                ResizeGrabber.Position = UDim2.fromOffset(
-                    ColorMenu.Menu.AbsolutePosition.X + ColorMenu.Menu.AbsoluteSize.X - GrabberInset,
-                    ColorMenu.Menu.AbsolutePosition.Y + ColorMenu.Menu.AbsoluteSize.Y - GrabberInset
-                )
-                ResizeGrabber.Visible = ColorMenu.Menu.Visible
-            end
-
-            table.insert(ColorPicker.Connections, ColorMenu.Menu:GetPropertyChangedSignal("AbsolutePosition"):Connect(UpdateGrabberPosition))
-            table.insert(ColorPicker.Connections, ColorMenu.Menu:GetPropertyChangedSignal("AbsoluteSize"):Connect(UpdateGrabberPosition))
-            table.insert(ColorPicker.Connections, ColorMenu.Menu:GetPropertyChangedSignal("Visible"):Connect(UpdateGrabberPosition))
 
             table.insert(ColorPicker.Connections, ResizeGrabber.InputBegan:Connect(function(Input: InputObject)
                 Library.CantDragForced = true
@@ -4203,14 +4268,12 @@ do
 
                 Library.CantDragForced = false
             end))
-
-            UpdateGrabberPosition()
         end
 
         local InfoHolder = New("Frame", {
             BackgroundTransparency = 1,
             Size = UDim2.new(1, 0, 0, 20),
-            Parent = ColorMenu.Menu,
+            Parent = ContentHolder,
         })
         New("UIListLayout", {
             FillDirection = Enum.FillDirection.Horizontal,
@@ -4320,7 +4383,7 @@ do
         local ActionHolder = New("Frame", {
             BackgroundTransparency = 1,
             Size = UDim2.new(1, 0, 0, 20),
-            Parent = ColorMenu.Menu,
+            Parent = ContentHolder,
         })
         New("UIListLayout", {
             FillDirection = Enum.FillDirection.Horizontal,
@@ -4465,6 +4528,8 @@ do
                 math.floor(ColorPicker.Value.G * 255),
                 math.floor(ColorPicker.Value.B * 255),
             }, ", ")
+
+            RefreshFooterInfo()
         end
 
         function ColorPicker:RunChanged()

--- a/Library.lua
+++ b/Library.lua
@@ -3970,8 +3970,6 @@ do
         ColorPicker.ColorMenu = ColorMenu
 
         --// Content Holder \\--
-        -- Everything above the footer lives in here, so the footer below can
-        -- span the full width/edge of the menu (matching the main window footer).
         local ContentHolder = New("Frame", {
             AutomaticSize = Enum.AutomaticSize.Y,
             BackgroundTransparency = 1,
@@ -3991,9 +3989,6 @@ do
         })
 
         --// Footer \\--
-        -- Copied from the main window's footer: a tinted bar under a divider
-        -- line, showing the current hex/rgb and (if resizable) hosting the
-        -- resize grabber, so the grabber no longer overlaps the paste button.
         local FooterHeight = Library.IsMobile and 30 or 22
 
         local FooterBackground = New("Frame", {
@@ -4234,11 +4229,6 @@ do
                 Position = UDim2.new(1, 0, 1, 0),
                 Size = UDim2.fromOffset(GrabberSize, GrabberSize),
                 Text = "",
-                -- Parented to FooterBackground (not FooterBar) so this Scale-based
-                -- position resolves against the footer's full bounds rather than
-                -- FooterBar's padded content area, which would otherwise pull it
-                -- inward by PaddingRight and land it near the text instead of the
-                -- true bottom-right corner.
                 Parent = FooterBackground,
             })
             New("ImageLabel", {

--- a/Library.lua
+++ b/Library.lua
@@ -4037,7 +4037,7 @@ do
 
         local function RefreshFooterInfo()
             FooterInfoLabel.Text = string.format(
-                "#%s  ·  %d, %d, %d",
+                "#%s • %d, %d, %d",
                 ColorPicker.Value:ToHex(),
                 math.floor(ColorPicker.Value.R * 255),
                 math.floor(ColorPicker.Value.G * 255),
@@ -4152,21 +4152,21 @@ do
         --// Resizing \\--
         local ResizeGrabber
         if Info.Resizable then
-            local BaseSquareSize = 200
+            local BaseMapSize = 200
             local BaseBarWidth = 16
             local BasePadding = 6
-            local MinSquareSize = 140
-            local MaxSquareSize = 320
+            local MinMapSize = 140
 
-            ColorPicker.SquareSize = BaseSquareSize
+            ColorPicker.MapWidth = BaseMapSize
+            ColorPicker.MapHeight = BaseMapSize
 
-            local function GetBarWidth(SquareSize)
-                return math.clamp(math.floor((SquareSize / BaseSquareSize) * BaseBarWidth + 0.5), 12, 24)
+            local function GetBarWidth(MapWidth)
+                return math.clamp(math.floor((MapWidth / BaseMapSize) * BaseBarWidth + 0.5), 12, 24)
             end
 
-            local function GetContentWidth(SquareSize)
-                local BarWidth = GetBarWidth(SquareSize)
-                local Width = SquareSize + BarWidth + BasePadding
+            local function GetContentWidth(MapWidth)
+                local BarWidth = GetBarWidth(MapWidth)
+                local Width = MapWidth + BarWidth + BasePadding
                 if Info.Transparency then
                     Width += (BarWidth + BasePadding)
                 end
@@ -4174,12 +4174,15 @@ do
                 return Width + 12
             end
 
-            local FixedVerticalOverhead = 90
+            local FixedVerticalOverhead = 6 + 6 + 8 + 20 + 8 + 20 + FooterHeight
+            if typeof(ColorPicker.Title) == "string" then
+                FixedVerticalOverhead += 8 + 8
+            end
 
-            local function ClampToViewport(NewSquareSize)
+            local function ClampToViewport(NewWidth, NewHeight)
                 local Camera = workspace.CurrentCamera
                 if not Camera then
-                    return NewSquareSize
+                    return NewWidth, NewHeight
                 end
 
                 local ViewportSize = Camera.ViewportSize
@@ -4188,70 +4191,72 @@ do
                 local MaxWidth = ViewportSize.X - ColorMenu.Menu.AbsolutePosition.X - ScreenMargin
                 local MaxHeight = ViewportSize.Y - ColorMenu.Menu.AbsolutePosition.Y - ScreenMargin - FixedVerticalOverhead
 
-                while NewSquareSize > MinSquareSize
-                    and (GetContentWidth(NewSquareSize) > MaxWidth or NewSquareSize > MaxHeight) do
-                    NewSquareSize -= 4
+                while NewWidth > MinMapSize and GetContentWidth(NewWidth) > MaxWidth do
+                    NewWidth -= 4
                 end
 
-                return NewSquareSize
+                if NewHeight > MaxHeight then
+                    NewHeight = math.max(MinMapSize, math.floor(MaxHeight))
+                end
+
+                return NewWidth, NewHeight
             end
 
-            local function UpdateColorMenuSize(NewSquareSize)
-                NewSquareSize = math.clamp(math.floor(NewSquareSize + 0.5), MinSquareSize, MaxSquareSize)
-                NewSquareSize = ClampToViewport(NewSquareSize)
+            local function UpdateColorMenuSize(NewWidth, NewHeight)
+                NewWidth = math.max(MinMapSize, math.floor(NewWidth + 0.5))
+                NewHeight = math.max(MinMapSize, math.floor(NewHeight + 0.5))
+                NewWidth, NewHeight = ClampToViewport(NewWidth, NewHeight)
 
-                if NewSquareSize == ColorPicker.SquareSize then
+                if NewWidth == ColorPicker.MapWidth and NewHeight == ColorPicker.MapHeight then
                     return
                 end
 
-                local BarWidth = GetBarWidth(NewSquareSize)
-                local CursorSize = math.clamp(math.floor((NewSquareSize / BaseSquareSize) * 6 + 0.5), 4, 10)
+                local BarWidth = GetBarWidth(NewWidth)
+                local CursorSize = math.clamp(math.floor((math.min(NewWidth, NewHeight) / BaseMapSize) * 6 + 0.5), 4, 10)
 
-                ColorHolder.Size = UDim2.new(1, 0, 0, NewSquareSize)
-                SatVipMap.Size = UDim2.fromOffset(NewSquareSize, NewSquareSize)
+                ColorHolder.Size = UDim2.new(1, 0, 0, NewHeight)
+                SatVipMap.Size = UDim2.fromOffset(NewWidth, NewHeight)
                 SatVibCursor.Size = UDim2.fromOffset(CursorSize, CursorSize)
-                HueSelector.Size = UDim2.new(0, BarWidth, 0, NewSquareSize)
+                HueSelector.Size = UDim2.new(0, BarWidth, 0, NewHeight)
 
                 if TransparencySelector then
-                    TransparencySelector.Size = UDim2.new(0, BarWidth, 0, NewSquareSize)
+                    TransparencySelector.Size = UDim2.new(0, BarWidth, 0, NewHeight)
                 end
 
-                ColorPicker.SquareSize = NewSquareSize
-                ColorMenu:SetSize(UDim2.new(0, GetContentWidth(NewSquareSize), 0, 0))
+                ColorPicker.MapWidth = NewWidth
+                ColorPicker.MapHeight = NewHeight
+                ColorMenu:SetSize(UDim2.new(0, GetContentWidth(NewWidth), 0, 0))
             end
 
-            local IconSize = 12
-            local GrabberSize = Library.IsMobile and 28 or 16
-
             ResizeGrabber = New("TextButton", {
-                AnchorPoint = Vector2.new(1, 1),
+                AnchorPoint = Vector2.new(1, 0),
                 BackgroundTransparency = 1,
-                Position = UDim2.new(1, 0, 1, 0),
-                Size = UDim2.fromOffset(GrabberSize, GrabberSize),
+                Position = UDim2.new(1, -Library.CornerRadius / 4, 0, 0),
+                Size = UDim2.fromScale(1, 1),
+                SizeConstraint = Enum.SizeConstraint.RelativeYY,
                 Text = "",
                 Parent = FooterBackground,
             })
             New("ImageLabel", {
-                AnchorPoint = Vector2.new(0.5, 0.5),
-                BackgroundTransparency = 1,
                 Image = ResizeIcon and ResizeIcon.Url or "",
                 ImageColor3 = "FontColor",
                 ImageRectOffset = ResizeIcon and ResizeIcon.ImageRectOffset or Vector2.zero,
                 ImageRectSize = ResizeIcon and ResizeIcon.ImageRectSize or Vector2.zero,
-                ImageTransparency = 0.35,
-                Position = UDim2.fromScale(0.5, 0.5),
-                Size = UDim2.fromOffset(IconSize, IconSize),
+                ImageTransparency = 0.5,
+                Position = UDim2.fromOffset(2, 2),
+                Size = UDim2.new(1, -4, 1, -4),
                 Parent = ResizeGrabber,
             })
 
             table.insert(ColorPicker.Connections, ResizeGrabber.InputBegan:Connect(function(Input: InputObject)
                 Library.CantDragForced = true
                 local StartMouse = Vector2.new(Mouse.X, Mouse.Y)
-                local StartSquareSize = ColorPicker.SquareSize
+                local StartWidth = ColorPicker.MapWidth
+                local StartHeight = ColorPicker.MapHeight
 
                 while IsDragInput(Input) and not ColorPicker.Destroyed do
                     local Delta = Vector2.new(Mouse.X, Mouse.Y) - StartMouse
-                    UpdateColorMenuSize(StartSquareSize + math.max(Delta.X, Delta.Y))
+                    UpdateColorMenuSize(StartWidth + Delta.X, StartHeight + Delta.Y)
 
                     RunService.RenderStepped:Wait()
                 end


### PR DESCRIPTION
- **Copy/Paste buttons in the popup menu** — Added "Copy color" / "Paste color" buttons directly inside the `ColorPicker`'s popup, sharing the same `Library.CopiedColor` state as the existing right-click menu. Right-click has no equivalent on touch screens, so mobile users previously had no way to copy/paste colors at all; this exposes the same functionality inline for them.
- **Resizable ColorPicker menu** — Added a drag handle to the bottom-right corner of the popup that scales the saturation/hue/alpha controls (140–320px). Added specifically for mobile: the fixed desktop-sized picker is a small, fiddly target on a phone screen, so this lets mobile users grow it to something they can actually see and drag accurately. Enabled by default via `Info.Resizable`, can be disabled per-picker.
```lua
LeftGroupBox:AddLabel("Color"):AddColorPicker("ColorPicker", {
	Default = Color3.new(0, 1, 0), -- Bright green
	Title = "colorpicker",
	Transparency = 0,
	Resizable = true, -- true/false

	Callback = function(Value)
		print("[cb] Color changed!", Value)
	end,
})
```
<img width="768" height="599" alt="image" src="https://github.com/user-attachments/assets/91249101-617f-4134-ad84-59c747aa8e56" />