### PR TITLE
Focus/hover visual feedback additions

### DIFF
--- a/Library.lua
+++ b/Library.lua
@@ -11362,11 +11362,6 @@ function Library:CreateWindow(WindowInfo)
         if UserInputService:GetFocusedTextBox() then
             return
         end
-
-        local ToggleKeybind = Library.ToggleKeybind
-        if typeof(ToggleKeybind) == "table" and (ToggleKeybind.Type == "KeyPicker" and ToggleKeybind.Mode ~= "Always" and ToggleKeybind:GetState() == true) or Input.KeyCode == ToggleKeybind then
-            Library:Toggle()
-        end
     end))
 
     Library:GiveSignal(UserInputService.WindowFocused:Connect(function()

--- a/Library.lua
+++ b/Library.lua
@@ -11362,6 +11362,10 @@ function Library:CreateWindow(WindowInfo)
         if UserInputService:GetFocusedTextBox() then
             return
         end
+
+        if Input.KeyCode == Library.ToggleKeybind then
+            Library:Toggle()
+        end
     end))
 
     Library:GiveSignal(UserInputService.WindowFocused:Connect(function()

--- a/Library.lua
+++ b/Library.lua
@@ -3321,6 +3321,28 @@ do
                 ModeButton:Select()
             end)
 
+            Button.MouseEnter:Connect(function()
+                if KeyPicker.Mode == Mode then
+                    return
+                end
+
+                TweenService:Create(Button, Library.TweenInfo, {
+                    BackgroundTransparency = 0.7,
+                    TextTransparency = 0.1,
+                }):Play()
+            end)
+
+            Button.MouseLeave:Connect(function()
+                if KeyPicker.Mode == Mode then
+                    return
+                end
+
+                TweenService:Create(Button, Library.TweenInfo, {
+                    BackgroundTransparency = 1,
+                    TextTransparency = 0.5,
+                }):Play()
+            end)
+
             if KeyPicker.Mode == Mode then
                 ModeButton:Select()
             end
@@ -3494,7 +3516,7 @@ do
                     return
                 end
 
-				KeyPicker.Toggled = true
+                KeyPicker.Toggled = true
             end
 
             Library:SafeCallback(KeyPicker.Callback, KeyPicker.Toggled)
@@ -3508,7 +3530,7 @@ do
                 Library:Toggle()
             end
 
-			if KeyPicker.Mode == "Press" then
+            if KeyPicker.Mode == "Press" then
                 KeyPicker.Toggled = false
             end
         end
@@ -4070,7 +4092,7 @@ do
             Parent = InfoHolder,
         })
 
-        New("UIStroke", {
+        local HueBoxStroke = New("UIStroke", {
             Color = "OutlineColor",
             Parent = HueBox,
         })
@@ -4092,7 +4114,7 @@ do
             Parent = InfoHolder,
         })
 
-        New("UIStroke", {
+        local RgbBoxStroke = New("UIStroke", {
             Color = "OutlineColor",
             Parent = RgbBox,
         })
@@ -4117,6 +4139,7 @@ do
         do
             local function CreateButton(Text, Func)
                 local Button = New("TextButton", {
+                    BackgroundColor3 = "MainColor",
                     BackgroundTransparency = 1,
                     Size = UDim2.new(1, 0, 0, 21),
                     Text = Text,
@@ -4127,6 +4150,18 @@ do
                 Button.MouseButton1Click:Connect(function()
                     Library:SafeCallback(Func)
                     ContextMenu:Close()
+                end)
+
+                Button.MouseEnter:Connect(function()
+                    TweenService:Create(Button, Library.TweenInfo, {
+                        BackgroundTransparency = 0.7,
+                    }):Play()
+                end)
+
+                Button.MouseLeave:Connect(function()
+                    TweenService:Create(Button, Library.TweenInfo, {
+                        BackgroundTransparency = 1,
+                    }):Play()
                 end)
             end
 
@@ -4305,6 +4340,24 @@ do
 
             ColorPicker:Update()
         end))
+
+        for _, BoxPair in ipairs({ { HueBox, HueBoxStroke }, { RgbBox, RgbBoxStroke } }) do
+            local TextBoxInstance, Stroke = BoxPair[1], BoxPair[2]
+
+            table.insert(ColorPicker.Connections, TextBoxInstance.Focused:Connect(function()
+                Library.Registry[Stroke].Color = "AccentColor"
+                TweenService:Create(Stroke, Library.TweenInfo, {
+                    Color = Library.Scheme.AccentColor,
+                }):Play()
+            end))
+
+            table.insert(ColorPicker.Connections, TextBoxInstance.FocusLost:Connect(function()
+                Library.Registry[Stroke].Color = "OutlineColor"
+                TweenService:Create(Stroke, Library.TweenInfo, {
+                    Color = Library.Scheme.OutlineColor,
+                }):Play()
+            end))
+        end
 
         ColorPicker:Display()
 
@@ -5622,7 +5675,7 @@ do
             Parent = Box,
         })
 
-        New("UIStroke", {
+        local BoxStroke = New("UIStroke", {
             Color = "OutlineColor",
             Parent = Box,
         })
@@ -5719,6 +5772,24 @@ do
                 Input:SetValue(Box.Text)
             end))
         end
+
+        table.insert(Input.Connections, Box.Focused:Connect(function()
+            if Input.Disabled then
+                return
+            end
+
+            Library.Registry[BoxStroke].Color = "AccentColor"
+            TweenService:Create(BoxStroke, Library.TweenInfo, {
+                Color = Library.Scheme.AccentColor,
+            }):Play()
+        end))
+
+        table.insert(Input.Connections, Box.FocusLost:Connect(function()
+            Library.Registry[BoxStroke].Color = "OutlineColor"
+            TweenService:Create(BoxStroke, Library.TweenInfo, {
+                Color = Library.Scheme.OutlineColor,
+            }):Play()
+        end))
 
         if typeof(Input.Tooltip) == "string" or typeof(Input.DisabledTooltip) == "string" then
             Input.TooltipTable = Library:AddTooltip(Input.Tooltip, Input.DisabledTooltip, Box)
@@ -6646,6 +6717,44 @@ do
                         Library:UpdateDependencyBoxes()
                         Library:SafeCallback(Dropdown.Callback, Dropdown.Value)
                         Library:SafeCallback(Dropdown.Changed, Dropdown.Value)
+                    end)
+
+                    Button.MouseEnter:Connect(function()
+                        if Selected then
+                            return
+                        end
+
+                        TweenService:Create(Container, Library.TweenInfo, {
+                            BackgroundTransparency = 0.85,
+                        }):Play()
+                        TweenService:Create(Button, Library.TweenInfo, {
+                            TextTransparency = 0.25,
+                        }):Play()
+
+                        if Image then
+                            TweenService:Create(Image, Library.TweenInfo, {
+                                ImageTransparency = 0.25,
+                            }):Play()
+                        end
+                    end)
+
+                    Button.MouseLeave:Connect(function()
+                        if Selected then
+                            return
+                        end
+
+                        TweenService:Create(Container, Library.TweenInfo, {
+                            BackgroundTransparency = 1,
+                        }):Play()
+                        TweenService:Create(Button, Library.TweenInfo, {
+                            TextTransparency = 0.5,
+                        }):Play()
+
+                        if Image then
+                            TweenService:Create(Image, Library.TweenInfo, {
+                                ImageTransparency = 0.5,
+                            }):Play()
+                        end
                     end)
 
                     if Info.Multi and Dropdown.DragSelect and not Library.IsMobile then
@@ -11173,7 +11282,8 @@ function Library:CreateWindow(WindowInfo)
             return
         end
 
-        if Input.KeyCode == Library.ToggleKeybind then
+        local ToggleKeybind = Library.ToggleKeybind
+        if typeof(ToggleKeybind) == "table" and (ToggleKeybind.Type == "KeyPicker" and ToggleKeybind.Mode ~= "Always" and ToggleKeybind:GetState() == true) or Input.KeyCode == ToggleKeybind then
             Library:Toggle()
         end
     end))

--- a/Library.lua
+++ b/Library.lua
@@ -3333,6 +3333,28 @@ do
                 ModeButton:Select()
             end)
 
+            Button.MouseEnter:Connect(function()
+                if KeyPicker.Mode == Mode then
+                    return
+                end
+
+                TweenService:Create(Button, Library.TweenInfo, {
+                    BackgroundTransparency = 0.7,
+                    TextTransparency = 0.1,
+                }):Play()
+            end)
+
+            Button.MouseLeave:Connect(function()
+                if KeyPicker.Mode == Mode then
+                    return
+                end
+
+                TweenService:Create(Button, Library.TweenInfo, {
+                    BackgroundTransparency = 1,
+                    TextTransparency = 0.5,
+                }):Play()
+            end)
+
             if KeyPicker.Mode == Mode then
                 ModeButton:Select()
             end
@@ -3506,7 +3528,7 @@ do
                     return
                 end
 
-				KeyPicker.Toggled = true
+                KeyPicker.Toggled = true
             end
 
             Library:SafeCallback(KeyPicker.Callback, KeyPicker.Toggled)
@@ -3520,7 +3542,7 @@ do
                 Library:Toggle()
             end
 
-			if KeyPicker.Mode == "Press" then
+            if KeyPicker.Mode == "Press" then
                 KeyPicker.Toggled = false
             end
         end
@@ -4099,7 +4121,7 @@ do
             Parent = InfoHolder,
         })
 
-        New("UIStroke", {
+        local HueBoxStroke = New("UIStroke", {
             Color = "OutlineColor",
             Parent = HueBox,
         })
@@ -4121,7 +4143,7 @@ do
             Parent = InfoHolder,
         })
 
-        New("UIStroke", {
+        local RgbBoxStroke = New("UIStroke", {
             Color = "OutlineColor",
             Parent = RgbBox,
         })
@@ -4146,6 +4168,7 @@ do
         do
             local function CreateButton(Text, Func)
                 local Button = New("TextButton", {
+                    BackgroundColor3 = "MainColor",
                     BackgroundTransparency = 1,
                     Size = UDim2.new(1, 0, 0, 21),
                     Text = Text,
@@ -4156,6 +4179,18 @@ do
                 Button.MouseButton1Click:Connect(function()
                     Library:SafeCallback(Func)
                     ContextMenu:Close()
+                end)
+
+                Button.MouseEnter:Connect(function()
+                    TweenService:Create(Button, Library.TweenInfo, {
+                        BackgroundTransparency = 0.7,
+                    }):Play()
+                end)
+
+                Button.MouseLeave:Connect(function()
+                    TweenService:Create(Button, Library.TweenInfo, {
+                        BackgroundTransparency = 1,
+                    }):Play()
                 end)
             end
 
@@ -4337,6 +4372,24 @@ do
 
             ColorPicker:Update()
         end))
+
+        for _, BoxPair in ipairs({ { HueBox, HueBoxStroke }, { RgbBox, RgbBoxStroke } }) do
+            local TextBoxInstance, Stroke = BoxPair[1], BoxPair[2]
+
+            table.insert(ColorPicker.Connections, TextBoxInstance.Focused:Connect(function()
+                Library.Registry[Stroke].Color = "AccentColor"
+                TweenService:Create(Stroke, Library.TweenInfo, {
+                    Color = Library.Scheme.AccentColor,
+                }):Play()
+            end))
+
+            table.insert(ColorPicker.Connections, TextBoxInstance.FocusLost:Connect(function()
+                Library.Registry[Stroke].Color = "OutlineColor"
+                TweenService:Create(Stroke, Library.TweenInfo, {
+                    Color = Library.Scheme.OutlineColor,
+                }):Play()
+            end))
+        end
 
         ColorPicker:Display()
 
@@ -5662,7 +5715,7 @@ do
             Parent = Box,
         })
 
-        New("UIStroke", {
+        local BoxStroke = New("UIStroke", {
             Color = "OutlineColor",
             Parent = Box,
         })
@@ -5763,6 +5816,24 @@ do
                 Input:SetValue(Box.Text)
             end))
         end
+
+        table.insert(Input.Connections, Box.Focused:Connect(function()
+            if Input.Disabled then
+                return
+            end
+
+            Library.Registry[BoxStroke].Color = "AccentColor"
+            TweenService:Create(BoxStroke, Library.TweenInfo, {
+                Color = Library.Scheme.AccentColor,
+            }):Play()
+        end))
+
+        table.insert(Input.Connections, Box.FocusLost:Connect(function()
+            Library.Registry[BoxStroke].Color = "OutlineColor"
+            TweenService:Create(BoxStroke, Library.TweenInfo, {
+                Color = Library.Scheme.OutlineColor,
+            }):Play()
+        end))
 
         if typeof(Input.Tooltip) == "string" or typeof(Input.DisabledTooltip) == "string" then
             Input.TooltipTable = Library:AddTooltip(Input.Tooltip, Input.DisabledTooltip, Box)
@@ -6866,6 +6937,44 @@ do
                 Library:UpdateDependencyBoxes()
                 Dropdown:RunChanged()
             end)
+
+			Button.MouseEnter:Connect(function()
+				if Selected then
+					return
+				end
+
+				TweenService:Create(Container, Library.TweenInfo, {
+					BackgroundTransparency = 0.85,
+				}):Play()
+				TweenService:Create(Button, Library.TweenInfo, {
+					TextTransparency = 0.25,
+				}):Play()
+
+				if Image then
+					TweenService:Create(Image, Library.TweenInfo, {
+						ImageTransparency = 0.25,
+					}):Play()
+				end
+			end)
+
+			Button.MouseLeave:Connect(function()
+				if Selected then
+					return
+				end
+
+				TweenService:Create(Container, Library.TweenInfo, {
+					BackgroundTransparency = 1,
+				}):Play()
+				TweenService:Create(Button, Library.TweenInfo, {
+					TextTransparency = 0.5,
+				}):Play()
+
+				if Image then
+					TweenService:Create(Image, Library.TweenInfo, {
+						ImageTransparency = 0.5,
+					}):Play()
+				end
+			end)
 
             Button.InputBegan:Connect(function(StartInput)
                 if not (Info.Multi and Dropdown.DragSelect and not Library.IsMobile) then

--- a/Library.lua
+++ b/Library.lua
@@ -6896,6 +6896,8 @@ do
                     Selected = Dropdown.Value == Entry.Value
                 end
 
+                Row.Selected = Selected and true or false
+
                 Container.BackgroundTransparency = Selected and 0 or 1
                 Button.TextTransparency = Entry.IsDisabled and 0.8 or Selected and 0 or 0.5
 
@@ -6939,7 +6941,7 @@ do
             end)
 
 			Button.MouseEnter:Connect(function()
-				if Selected then
+				if Row.Selected then
 					return
 				end
 
@@ -6958,7 +6960,7 @@ do
 			end)
 
 			Button.MouseLeave:Connect(function()
-				if Selected then
+				if Row.Selected then
 					return
 				end
 

--- a/Library.lua
+++ b/Library.lua
@@ -4373,7 +4373,10 @@ do
             ColorPicker:Update()
         end))
 
-        for _, BoxPair in ipairs({ { HueBox, HueBoxStroke }, { RgbBox, RgbBoxStroke } }) do
+        for _, BoxPair in { 
+            { HueBox, HueBoxStroke }, 
+            { RgbBox, RgbBoxStroke } 
+        } do
             local TextBoxInstance, Stroke = BoxPair[1], BoxPair[2]
 
             table.insert(ColorPicker.Connections, TextBoxInstance.Focused:Connect(function()


### PR DESCRIPTION
This PR adds tween-based visual feedback to two previously static interaction states, both reusing the existing `Library.TweenInfo` (0.1s) timing rather than introducing new animation parameters:

1. **TextBox focus border** — `Input`, plus the ColorPicker's Hue/RGB boxes, now tween `UIStroke.Color` between `OutlineColor` and `AccentColor` on `Focused`/`FocusLost`. Previously the only focus indicator was the blinking cursor, which was easy to lose track of when multiple text boxes were stacked in a groupbox.

2. **Dropdown & menu item hover** — Hover tweens added to the Dropdown value list, KeyPicker mode-select buttons, and the ColorPicker's right-click menu (Copy/Paste color, Copy Hex, Copy RGB), shifting background/text transparency on `MouseEnter`/`MouseLeave`. Brings these list-style items in line with the hover feedback already present on buttons and checkboxes.

**Why are these not beyond the Animations flag?** both changes are single-property color/transparency tweens on native input events (focus, mouse enter/leave) — not structural transitions. The `Animations` flag only covers larger transitions (window show/hide, tab switching, dropdown expand, etc.) that have a meaningful "instant" fallback to snap to. These are classed with the existing unconditional hover/toggle tweens (e.g. `Toggle:Display`), so no opt-out is offered.

(This GIF seems to look slightly stretched and get slightly cutoff due to GitHub page size and having a few skill issues when making the GIF)
<img width="1232" height="1040" alt="ezgif-1720f0bf714ee758" src="https://github.com/user-attachments/assets/d78cff97-0a17-4c16-9734-686b72d9054d" />