### PR TITLE
feat: add Order support for Tabs

### DIFF
--- a/Library.d.luau
+++ b/Library.d.luau
@@ -745,6 +745,7 @@ export type Tab = {
     Show: (self: Tab) -> (),
     Hide: (self: Tab) -> (),
     SetVisible: (self: Tab, Visible: boolean) -> (),
+    SetOrder: (self: Tab, Order: number) -> (),
 }
 
 export type KeyTab = BaseGroupbox & {
@@ -849,9 +850,10 @@ export type Window = {
     HideTabInfo: (self: Window) -> (),
     AddTab: (
         self: Window,
-        Info: { Name: string, Icon: string?, Description: string? } | string,
+        Info: { Name: string, Icon: string?, Description: string?, Order: number? } | string,
         Icon: string?,
-        Description: string?
+        Description: string?,
+        Order: number?
     ) -> Tab,
     AddKeyTab: (
         self: Window,

--- a/Library.lua
+++ b/Library.lua
@@ -9056,16 +9056,19 @@ function Library:CreateWindow(WindowInfo)
         local Name = nil
         local Icon = nil
         local Description = nil
+        local Order = nil
 
         if select("#", ...) == 1 and typeof(...) == "table" then
             local Info = select(1, ...)
             Name = Info.Name or "Tab"
             Icon = Info.Icon
             Description = Info.Description
+            Order = Info.Order
         else
             Name = select(1, ...)
             Icon = select(2, ...)
             Description = select(3, ...)
+            Order = select(4, ...)
         end
 
         local TabButton: TextButton
@@ -9084,6 +9087,7 @@ function Library:CreateWindow(WindowInfo)
                 BackgroundTransparency = 1,
                 Size = UDim2.new(1, 0, 0, 40),
                 Text = "",
+                LayoutOrder = Order,
                 Parent = Tabs,
             })
             local ButtonPadding = New("UIPadding", {
@@ -10122,6 +10126,10 @@ function Library:CreateWindow(WindowInfo)
             if not Visible and Library.ActiveTab == Tab then
                 Tab:Hide()
             end
+        end
+
+        function Tab:SetOrder(Order: number)
+            TabButton.LayoutOrder = Order
         end
 
         function Tab:Destroy()


### PR DESCRIPTION
The [documentation](https://docs.mspaint.cc/obsidian) states that `Tab:SetOrder(number)` exists, but it wasn't actually implemented. This PR adds support for `Tab:SetOrder(number)` and the `Order` option in `Window:AddTab()` to match the documented API.