### PR TITLE
Add theme JSON import/export

### DIFF
--- a/addons/SaveManager.lua
+++ b/addons/SaveManager.lua
@@ -300,7 +300,7 @@ end
 function SaveManager:IgnoreThemeSettings()
     SaveManager:SetIgnoreIndexes({
         "BackgroundColor", "MainColor", "AccentColor", "OutlineColor", "FontColor", "FontFace", "BackgroundImage",
-        "ThemeManager_ThemeList", "ThemeManager_CustomThemeList", "ThemeManager_CustomThemeName"
+        "ThemeManager_ThemeList", "ThemeManager_CustomThemeList", "ThemeManager_CustomThemeName", "ThemeManager_ThemeJSON"
     })
 end
 

--- a/addons/ThemeManager.lua
+++ b/addons/ThemeManager.lua
@@ -136,6 +136,21 @@ local function IsValidFolderPath(Name: string): boolean
     )
 end
 
+local function IsValidThemeData(Data: any): boolean
+    if typeof(Data) ~= "table" then
+        return false
+    end
+
+    --// Require the color scheme to be present; font/background image are optional and fall back to current values
+    for _, SchemeIndex in SchemeIndexes do
+        if typeof(Data[SchemeIndex]) ~= "string" then
+            return false
+        end
+    end
+
+    return true
+end
+
 --// Folder helper \\--
 local function SplitPath(Path: string): {string}
 	local Result = {}
@@ -268,6 +283,20 @@ function ThemeManager:GetCustomTheme(ThemeName: string): any
     return Decoded
 end
 
+local function BuildCurrentThemeData(): {[string]: any}
+    local Library = ThemeManager.Library
+    local ThemeData = {
+        FontFace = Library.Options.FontFace.Value,
+        BackgroundImage = Library.Options.BackgroundImage.Value
+    }
+
+    for _, SchemeIndex in SchemeIndexes do
+        ThemeData[SchemeIndex] = Library.Options[SchemeIndex].Value:ToHex()
+    end
+
+    return ThemeData
+end
+
 function ThemeManager:SaveCustomTheme(ThemeName: string): any
     if IsStringEmpty(ThemeName) then
         return false, "Invalid theme name provided"
@@ -284,19 +313,10 @@ function ThemeManager:SaveCustomTheme(ThemeName: string): any
 
     ThemeManager:CheckFolderTree()
 
-    local Library = ThemeManager.Library
-    local ThemeData = {
-        FontFace = Library.Options.FontFace.Value,
-        BackgroundImage = Library.Options.BackgroundImage.Value
-    }
-
-    for _, SchemeIndex in SchemeIndexes do
-        ThemeData[SchemeIndex] = Library.Options[SchemeIndex].Value:ToHex()
-    end
-
-    local SuccessEncode, EncodedData = pcall(HttpService.JSONEncode, HttpService, ThemeData)
+    --// Custom theme files use the same flat shape as an exported theme JSON, so reuse the encoder
+    local EncodedData, SuccessEncode, EncodeErrorMessage = ThemeManager:SaveJSON()
     if not SuccessEncode then
-        return false, "Failed to encode data"
+        return false, EncodeErrorMessage
     end
 
     local SuccessWrite, ErrorMessage = pcall(writefile, ThemePath, EncodedData)
@@ -498,6 +518,51 @@ function ThemeManager:ThemeUpdate()
     Library:UpdateColorsUsingRegistry()
 end
 
+--// Applies a flat theme data table (either a parsed theme file or an imported JSON blob) to the library.
+--// Split out of ApplyTheme so imported JSON can go through the same path as themes loaded from disk.
+function ThemeManager:ApplyThemeData(ThemeData: any): (boolean, string?)
+    if typeof(ThemeData) ~= "table" then
+        return false, "Invalid theme data"
+    end
+
+    local Library = ThemeManager.Library
+
+    for Index, Value in ThemeData do
+        if Index == "VideoLink" then
+            continue
+        end
+
+        local Element = Library.Options[Index]
+        local FinalValue = Value
+
+        if Index == "FontFace" then
+            if typeof(Value) ~= "string" or not Enum.Font[Value] then continue end
+            ThemeManager.Library:SetFont(Enum.Font[Value])
+
+        elseif Index == "BackgroundImage" then
+            if typeof(Value) ~= "string" then continue end
+            ThemeManager.Library:SetBackgroundImage(Value)
+
+        elseif table.find(SchemeIndexes, Index) then
+            local SuccessColor, Color = pcall(Color3.fromHex, Value)
+            if not SuccessColor then continue end
+
+            FinalValue = Color
+            Library.Scheme[Index] = FinalValue
+
+        else
+            continue --// Unrecognized field, ignore it
+        end
+
+        if Element then
+            Element:SetValue(FinalValue)
+        end
+    end
+
+    ThemeManager:ThemeUpdate()
+    return true
+end
+
 function ThemeManager:ApplyTheme(ThemeName: string)
     if IsStringEmpty(ThemeName) then
         return false, "No theme is selected"
@@ -510,36 +575,33 @@ function ThemeManager:ApplyTheme(ThemeName: string)
         return false, "Theme not found"
     end
     
-    local Library = ThemeManager.Library
-    local SchemeData = Data[2]
-    local ThemeData = CustomThemeData or SchemeData
+    local ThemeData = CustomThemeData or Data[2]
+    return ThemeManager:ApplyThemeData(ThemeData)
+end
 
-    for Index, Value in ThemeData do
-        if Index == "VideoLink" then
-            continue
-        end
+--// JSON Import & Export \\--
+function ThemeManager:SaveJSON(): (string, boolean, string?)
+    local ThemeData = BuildCurrentThemeData()
 
-        local Element = Library.Options[Index]
-        local FinalValue = Value
-
-        if Index == "FontFace" then
-            ThemeManager.Library:SetFont(Enum.Font[FinalValue])
-
-        elseif Index == "BackgroundImage" then
-            ThemeManager.Library:SetBackgroundImage(FinalValue)
-
-        else
-            FinalValue = Color3.fromHex(Value)
-            Library.Scheme[Index] = FinalValue
-        end
-
-        if Element then
-            Element:SetValue(FinalValue)
-        end
+    local SuccessEncode, EncodedData = pcall(HttpService.JSONEncode, HttpService, ThemeData)
+    if not SuccessEncode then
+        return "", false, "Failed to encode data"
     end
 
-    ThemeManager:ThemeUpdate()
-    return true
+    return EncodedData, true
+end
+
+function ThemeManager:LoadJSON(Content: string): (boolean, string?)
+    if IsStringEmpty(Content) then
+        return false, "No JSON provided"
+    end
+
+    local SuccessDecode, Decoded = pcall(HttpService.JSONDecode, HttpService, Content)
+    if not SuccessDecode or not IsValidThemeData(Decoded) then
+        return false, "Failed to decode theme data"
+    end
+
+    return ThemeManager:ApplyThemeData(Decoded)
 end
 
 --// GUI \\--
@@ -593,7 +655,7 @@ function ThemeManager:CreateThemeManager(Themesbox: any)
         table.insert(BuiltInThemesNames, Name)
     end
 
-    local CustomThemeList, CustomThemeName, ThemeList, FontFace, BackgroundImage, DefaultThemeLabel
+    local CustomThemeList, CustomThemeName, ThemeList, FontFace, BackgroundImage, DefaultThemeLabel, ThemeJSONInput
     local function RefreshList()
         CustomThemeList:SetValues(ThemeManager:ReloadCustomThemes())
         CustomThemeList:SetValue(nil)
@@ -848,13 +910,64 @@ function ThemeManager:CreateThemeManager(Themesbox: any)
 
     DefaultThemeLabel = Themesbox:AddLabel("Current default theme: ...", true);
 
+    Themesbox:AddDivider()
+
+    --// Import & Export
+    Themesbox:AddInput("ThemeManager_ThemeJSON", {
+        Text = "Theme JSON"
+    })
+
+    Themesbox:AddButton("Import theme", function()
+        local ThemeJSON = ThemeJSONInput.Value
+        if IsStringEmpty(ThemeJSON) then
+            ThemeManager.Library:Notify("Theme JSON cannot be empty")
+            return
+        end
+
+        ShowDialog(
+            function(): boolean
+                return true
+            end,
+
+            "ThemeManager_ImportTheme",
+            "Import theme",
+            "Are you sure you want to import this theme? Your current colors will be overwritten.",
+
+            "Import",
+            function()
+                local Success, ErrorMessage = ThemeManager:LoadJSON(ThemeJSON)
+                if not Success then
+                    ThemeManager.Library:Notify(string.format("Failed to import theme: %s", ErrorMessage))
+                    return
+                end
+
+                ThemeManager.Library:Notify("Successfully imported theme")
+            end
+        )
+    end)
+
+    Themesbox:AddButton("Export current theme", function()
+        local EncodedData, Success, ErrorMessage = ThemeManager:SaveJSON()
+        if not Success then
+            ThemeManager.Library:Notify(ErrorMessage)
+            return
+        end
+
+        ThemeJSONInput:SetValue(EncodedData)
+        if setclipboard then
+            setclipboard(EncodedData)
+            ThemeManager.Library:Notify("Copied theme to your clipboard")
+        end
+    end)
+
     --// Set Variables
-    CustomThemeList, CustomThemeName, ThemeList, FontFace, BackgroundImage =
+    CustomThemeList, CustomThemeName, ThemeList, FontFace, BackgroundImage, ThemeJSONInput =
         ThemeManager.Library.Options.ThemeManager_CustomThemeList,
         ThemeManager.Library.Options.ThemeManager_CustomThemeName,
         ThemeManager.Library.Options.ThemeManager_ThemeList,
         ThemeManager.Library.Options.FontFace,
-        ThemeManager.Library.Options.BackgroundImage;
+        ThemeManager.Library.Options.BackgroundImage,
+        ThemeManager.Library.Options.ThemeManager_ThemeJSON;
 
     --// Handlers
     ThemeList:OnChanged(function()


### PR DESCRIPTION
Right now trying someone else's theme means: download the file, find
the Obsidian settings folder, drop the file in the right subfolder,
restart/reload. That's a lot of friction for someone who just wants
to see what a theme looks like, especially for less technical users.
Paste-in JSON collapses that to one copy/paste.

___

## Details

Adds JSON import/export for themes, mirroring the Config JSON /
Import Config / Export current config section in SaveManager's
Configuration box, but built for ThemeManager instead.

New in the Themes groupbox, right after the default-theme controls:
- "Theme JSON" input
- "Import theme" — decodes and applies pasted JSON, behind the same
  confirmation dialog used for other destructive actions
- "Export current theme" — encodes the current colors/font/background
  image, fills the input, and copies it to clipboard

## Implementation

- `ThemeManager:SaveJSON()` — encodes the current theme to the same
  flat JSON shape already used for saved custom theme files, so
  exported JSON and on-disk theme files are interchangeable.
- `ThemeManager:LoadJSON(Content)` — decodes and validates the JSON
  has the expected color scheme fields before applying it.
- `ThemeManager:ApplyThemeData(ThemeData)` — pulled out of the old
  `ApplyTheme` so both loading a saved theme by name and loading
  pasted JSON go through one path. This is also where the actual
  input-hardening happens: `Color3.fromHex` calls are wrapped in
  `pcall`, font names are checked against `Enum.Font`, and unknown
  keys are ignored, so one bad field in a hand-pasted blob doesn't
  explode the whole import. The old code never needed this because
  it only ever saw theme data it wrote itself.
- `SaveCustomTheme` now calls `SaveJSON()` instead of duplicating the
  encode step.
- `SaveManager:IgnoreThemeSettings()` now also ignores
  `ThemeManager_ThemeJSON`, same as the other theme controls, so the
  input doesn't get pulled into regular bot configs.

## Notes for review

Malformed fields in imported JSON are skipped rather than failing the
whole import — felt like the right default for a paste-in feature
aimed at less technical users, but flagging in case a hard fail is
preferred instead.

___

## Example exported theme
```json
{"MainColor":"1c1c1c","FontFace":"Code","FontColor":"bf0004","OutlineColor":"323232","BackgroundColor":"141414","BackgroundImage":"","AccentColor":"840003"}
```

## Theme exporting
##### (It's hard to notice the `json` data above in the Theme JSON input because GIF compression killed the GIF)
<img width="800" height="660" alt="export" src="https://github.com/user-attachments/assets/002f86c0-0eca-4eac-976c-52bb7751387f" />

## Theme importing
<img width="800" height="660" alt="import" src="https://github.com/user-attachments/assets/3ea88443-75c2-4537-af4f-1e313b7ed104" />