### PR TITLE
Add window snapping to screen edges/center

### DIFF
--- a/Library.lua
+++ b/Library.lua
@@ -2,6 +2,7 @@ local cloneref = (cloneref or clonereference or function(instance: any)
     return instance
 end)
 local CoreGui: CoreGui = cloneref(game:GetService("CoreGui"))
+local GuiService: GuiService = cloneref(game:GetService("GuiService"))
 local Players: Players = cloneref(game:GetService("Players"))
 local RunService: RunService = cloneref(game:GetService("RunService"))
 local SoundService: SoundService = cloneref(game:GetService("SoundService"))
@@ -365,6 +366,12 @@ local Templates = {
         Center = true,
         Resizable = true,
         AlwaysOnTop = false,
+
+        --// Window Snapping \\--
+        Snapping = true,
+        SnapDistance = 28,
+        SnapMargin = 8,
+        SnapAvoidCoreGui = true,
 
         SearchbarSize = UDim2.fromScale(1, 1),
         GlobalSearch = false,
@@ -1597,13 +1604,129 @@ function PositionDraggable(UI: GuiObject, StartPos: UDim2?)
     UI.Position = GetNonOverlappingPosition(UI, StartPos)
 end
 
-function Library:MakeDraggable(UI: GuiObject, DragFrame: GuiObject, IgnoreToggled: boolean?, IsMainWindow: boolean?)
+--// Window Snapping \\--
+-- Reads Roblox's own topbar inset (menu, chat toggle, player list, backpack, etc.) so window
+-- snapping can avoid sitting underneath or behind Roblox's interface. GuiService:GetGuiInset()
+-- is the same inset ScreenGuis with IgnoreGuiInset = false already respect.
+local function GetCoreGuiInset(): (Vector2, Vector2)
+    local Success, TopLeft, BottomRight = pcall(function()
+        return GuiService:GetGuiInset()
+    end)
+
+    if Success and TopLeft and BottomRight then
+        return TopLeft, BottomRight
+    end
+
+    return Vector2.zero, Vector2.zero
+end
+
+-- Computes the magnetic X/Y targets (screen Edges + Center) an element can snap to, keyed by name
+-- so callers can tell exactly which Edge (or Center) matched. When AvoidCoreGui is true, the
+-- "safe area" used for these targets excludes whatever space Roblox's own topbar currently
+-- occupies, so Edges/Center land below and around it instead of underneath it.
+local function GetSnapEdges(ElemSize: Vector2, ViewportSize: Vector2, Margin: number, AvoidCoreGui: boolean)
+    local SafeMin, SafeMax = Vector2.zero, ViewportSize
+
+    if AvoidCoreGui then
+        local TopLeftInset, BottomRightInset = GetCoreGuiInset()
+        SafeMin = TopLeftInset
+        SafeMax = ViewportSize - BottomRightInset
+    end
+
+    local TargetsX = {
+        LeftEdge = SafeMin.X + Margin,
+        Center = SafeMin.X + (SafeMax.X - SafeMin.X - ElemSize.X) / 2,
+        RightEdge = SafeMax.X - ElemSize.X - Margin,
+    }
+    local TargetsY = {
+        TopEdge = SafeMin.Y + Margin,
+        Center = SafeMin.Y + (SafeMax.Y - SafeMin.Y - ElemSize.Y) / 2,
+        BottomEdge = SafeMax.Y - ElemSize.Y - Margin,
+    }
+
+    return TargetsX, TargetsY
+end
+
+-- Finds the closest named target within Distance on a single axis, or nil if nothing is close enough.
+local function GetClosestSnapTarget(Value: number, Targets: { [string]: number }, Distance: number): (number?, string?)
+    local ClosestName, ClosestValue, ClosestDist = nil, nil, Distance
+
+    for Name, Target in Targets do
+        local Dist = math.abs(Value - Target)
+        if Dist <= ClosestDist then
+            ClosestDist = Dist
+            ClosestName = Name
+            ClosestValue = Target
+        end
+    end
+
+    return ClosestValue, ClosestName
+end
+
+-- Converts a snapped axis value into the screen-space coordinate the guide line should be drawn
+-- at, so it sits flush with the screen Edge (or through the true Center) rather than through the
+-- middle of the dragged element.
+local function GetSnapGuideOffset(Name: string, SnappedValue: number, ElemDimension: number): number
+    if Name == "RightEdge" or Name == "BottomEdge" then
+        return SnappedValue + ElemDimension
+    elseif Name == "Center" then
+        return SnappedValue + ElemDimension / 2
+    end
+
+    return SnappedValue -- LeftEdge / TopEdge
+end
+
+function Library:MakeDraggable(
+    UI: GuiObject,
+    DragFrame: GuiObject,
+    IgnoreToggled: boolean?,
+    IsMainWindow: boolean?,
+    SnapConfig: { Enabled: boolean, Distance: number?, Margin: number?, AvoidCoreGui: boolean? }?
+)
     local StartPos
     local FramePos
     local Dragging = false
     local Changed
     local InputBegan
     local InputChanged
+
+    local SnapGuideX, SnapGuideY
+
+    local function GetSnapGuides()
+        if not SnapGuideX then
+            SnapGuideX = New("Frame", {
+                BackgroundColor3 = "AccentColor",
+                BackgroundTransparency = 0.25,
+                BorderSizePixel = 0,
+                AnchorPoint = Vector2.new(0.5, 0),
+                Size = UDim2.new(0, 2, 1, 0),
+                Visible = false,
+                ZIndex = 10000,
+                Parent = ScreenGui,
+            })
+            SnapGuideY = New("Frame", {
+                BackgroundColor3 = "AccentColor",
+                BackgroundTransparency = 0.25,
+                BorderSizePixel = 0,
+                AnchorPoint = Vector2.new(0, 0.5),
+                Size = UDim2.new(1, 0, 0, 2),
+                Visible = false,
+                ZIndex = 10000,
+                Parent = ScreenGui,
+            })
+        end
+
+        return SnapGuideX, SnapGuideY
+    end
+
+    local function HideSnapGuides()
+        if SnapGuideX then
+            SnapGuideX.Visible = false
+        end
+        if SnapGuideY then
+            SnapGuideY.Visible = false
+        end
+    end
 
     InputBegan = DragFrame.InputBegan:Connect(function(Input: InputObject)
         if not IsClickInput(Input) or IsMainWindow and Library.CantDragForced then
@@ -1620,6 +1743,8 @@ function Library:MakeDraggable(UI: GuiObject, DragFrame: GuiObject, IgnoreToggle
             end
 
             Dragging = false
+            HideSnapGuides()
+
             if Changed and Changed.Connected then
                 Changed:Disconnect()
                 Changed = nil
@@ -1634,6 +1759,8 @@ function Library:MakeDraggable(UI: GuiObject, DragFrame: GuiObject, IgnoreToggle
             or not (ScreenGui and ScreenGui.Parent)
         then
             Dragging = false
+            HideSnapGuides()
+
             if Changed and Changed.Connected then
                 Changed:Disconnect()
                 Changed = nil
@@ -1644,8 +1771,45 @@ function Library:MakeDraggable(UI: GuiObject, DragFrame: GuiObject, IgnoreToggle
 
         if Dragging and IsHoverInput(Input) then
             local Delta = Input.Position - StartPos
-            UI.Position =
-                UDim2.new(FramePos.X.Scale, FramePos.X.Offset + Delta.X, FramePos.Y.Scale, FramePos.Y.Offset + Delta.Y)
+            local NewX = FramePos.X.Offset + Delta.X
+            local NewY = FramePos.Y.Offset + Delta.Y
+
+            if SnapConfig and SnapConfig.Enabled then
+                local ViewportSize = workspace.CurrentCamera and workspace.CurrentCamera.ViewportSize
+                    or Vector2.new(1920, 1080)
+                local Distance = SnapConfig.Distance or 28
+                local Margin = SnapConfig.Margin or 8
+
+                -- Resolve to absolute screen-space so Edges/Center line up regardless of the
+                -- element's current Scale anchor (e.g. a window that started Centered).
+                local AbsX = FramePos.X.Scale * ViewportSize.X + NewX
+                local AbsY = FramePos.Y.Scale * ViewportSize.Y + NewY
+
+                local ElemSize = UI.AbsoluteSize
+                local TargetsX, TargetsY = GetSnapEdges(ElemSize, ViewportSize, Margin, SnapConfig.AvoidCoreGui ~= false)
+                local SnappedX, SnappedXName = GetClosestSnapTarget(AbsX, TargetsX, Distance)
+                local SnappedY, SnappedYName = GetClosestSnapTarget(AbsY, TargetsY, Distance)
+
+                if SnappedX then
+                    NewX = SnappedX - FramePos.X.Scale * ViewportSize.X
+                end
+                if SnappedY then
+                    NewY = SnappedY - FramePos.Y.Scale * ViewportSize.Y
+                end
+
+                local GuideX, GuideY = GetSnapGuides()
+                GuideX.Visible = SnappedX ~= nil
+                if SnappedX then
+                    GuideX.Position = UDim2.fromOffset(GetSnapGuideOffset(SnappedXName, SnappedX, ElemSize.X), 0)
+                end
+
+                GuideY.Visible = SnappedY ~= nil
+                if SnappedY then
+                    GuideY.Position = UDim2.fromOffset(0, GetSnapGuideOffset(SnappedYName, SnappedY, ElemSize.Y))
+                end
+            end
+
+            UI.Position = UDim2.new(FramePos.X.Scale, NewX, FramePos.Y.Scale, NewY)
         end
     end)
 
@@ -1663,6 +1827,13 @@ function Library:MakeDraggable(UI: GuiObject, DragFrame: GuiObject, IgnoreToggle
 
         if Changed and Changed.Connected then
             Changed:Disconnect()
+        end
+
+        if SnapGuideX then
+            SnapGuideX:Destroy()
+        end
+        if SnapGuideY then
+            SnapGuideY:Destroy()
         end
 
         local IdxChanged = table.find(Library.Signals, InputChanged)
@@ -9160,6 +9331,8 @@ function Library:CreateWindow(WindowInfo)
     WindowInfo.SidebarCompactWidth = math.max(48, WindowInfo.SidebarCompactWidth)
     WindowInfo.SidebarCollapseThreshold = math.clamp(WindowInfo.SidebarCollapseThreshold, 0.1, 0.9)
     WindowInfo.CompactWidthActivation = math.max(48, WindowInfo.CompactWidthActivation)
+    WindowInfo.SnapDistance = math.max(0, WindowInfo.SnapDistance)
+    WindowInfo.SnapMargin = math.max(0, WindowInfo.SnapMargin)
 
     Library.CornerRadius = WindowInfo.CornerRadius
     Library:SetNotifySide(WindowInfo.NotifySide)
@@ -9195,6 +9368,7 @@ function Library:CreateWindow(WindowInfo)
     local BottomBackground
     local FooterLabel
     local TopBar
+    local WindowSnapConfig
 
     local InitialLeftWidth = math.ceil(WindowInfo.Size.X.Offset * 0.3)
     local IsCompact = WindowInfo.SidebarCompacted
@@ -9277,7 +9451,13 @@ function Library:CreateWindow(WindowInfo)
             Size = UDim2.new(1, 0, 0, 48),
             Parent = MainFrame,
         })
-        Library:MakeDraggable(MainFrame, TopBar, false, true)
+        WindowSnapConfig = {
+            Enabled = WindowInfo.Snapping,
+            Distance = WindowInfo.SnapDistance,
+            Margin = WindowInfo.SnapMargin,
+            AvoidCoreGui = WindowInfo.SnapAvoidCoreGui,
+        }
+        Library:MakeDraggable(MainFrame, TopBar, false, true, WindowSnapConfig)
 
         --// Title \\--
         TitleHolder = New("Frame", {
@@ -9650,6 +9830,26 @@ function Library:CreateWindow(WindowInfo)
     function Window:SetAlwaysOnTop(Enabled: boolean)
         WindowInfo.AlwaysOnTop = Enabled == true
         SetAlwaysOnTop(Library.ScreenGui, WindowInfo.AlwaysOnTop)
+    end
+
+    function Window:SetSnapping(Enabled: boolean, Distance: number?, Margin: number?, AvoidCoreGui: boolean?)
+        WindowInfo.Snapping = Enabled == true
+        WindowSnapConfig.Enabled = WindowInfo.Snapping
+
+        if Distance then
+            WindowInfo.SnapDistance = math.max(0, Distance)
+            WindowSnapConfig.Distance = WindowInfo.SnapDistance
+        end
+
+        if Margin then
+            WindowInfo.SnapMargin = math.max(0, Margin)
+            WindowSnapConfig.Margin = WindowInfo.SnapMargin
+        end
+
+        if AvoidCoreGui ~= nil then
+            WindowInfo.SnapAvoidCoreGui = AvoidCoreGui == true
+            WindowSnapConfig.AvoidCoreGui = WindowInfo.SnapAvoidCoreGui
+        end
     end
 
     function Window:SetCornerRadius(Radius: number)

--- a/Library.lua
+++ b/Library.lua
@@ -368,7 +368,7 @@ local Templates = {
         AlwaysOnTop = false,
 
         --// Window Snapping \\--
-        Snapping = true,
+        Snapping = false,
         SnapDistance = 28,
         SnapMargin = 8,
         SnapAvoidCoreGui = true,
@@ -1693,6 +1693,9 @@ function Library:MakeDraggable(
                 ZIndex = 10000,
                 Parent = ScreenGui,
             })
+        end
+
+        if not SnapGuideY then
             SnapGuideY = New("Frame", {
                 BackgroundColor3 = "AccentColor",
                 BackgroundTransparency = 0.25,
@@ -1764,8 +1767,7 @@ function Library:MakeDraggable(
             local NewY = FramePos.Y.Offset + Delta.Y
 
             if SnapConfig and SnapConfig.Enabled then
-                local ViewportSize = workspace.CurrentCamera and workspace.CurrentCamera.ViewportSize
-                    or Vector2.new(1920, 1080)
+                local ViewportSize = workspace.CurrentCamera and workspace.CurrentCamera.ViewportSize or Vector2.new(1920, 1080)
                 local Distance = SnapConfig.Distance or 28
                 local Margin = SnapConfig.Margin or 8
 
@@ -9355,7 +9357,12 @@ function Library:CreateWindow(WindowInfo)
     local BottomBackground
     local FooterLabel
     local TopBar
-    local WindowSnapConfig
+    local WindowSnapConfig = {
+        Enabled = WindowInfo.Snapping,
+        Distance = WindowInfo.SnapDistance,
+        Margin = WindowInfo.SnapMargin,
+        AvoidCoreGui = WindowInfo.SnapAvoidCoreGui,
+    }
 
     local InitialLeftWidth = math.ceil(WindowInfo.Size.X.Offset * 0.3)
     local IsCompact = WindowInfo.SidebarCompacted
@@ -9438,12 +9445,6 @@ function Library:CreateWindow(WindowInfo)
             Size = UDim2.new(1, 0, 0, 48),
             Parent = MainFrame,
         })
-        WindowSnapConfig = {
-            Enabled = WindowInfo.Snapping,
-            Distance = WindowInfo.SnapDistance,
-            Margin = WindowInfo.SnapMargin,
-            AvoidCoreGui = WindowInfo.SnapAvoidCoreGui,
-        }
         Library:MakeDraggable(MainFrame, TopBar, false, true, WindowSnapConfig)
 
         --// Title \\--

--- a/Library.lua
+++ b/Library.lua
@@ -1605,9 +1605,6 @@ function PositionDraggable(UI: GuiObject, StartPos: UDim2?)
 end
 
 --// Window Snapping \\--
--- Reads Roblox's own topbar inset (menu, chat toggle, player list, backpack, etc.) so window
--- snapping can avoid sitting underneath or behind Roblox's interface. GuiService:GetGuiInset()
--- is the same inset ScreenGuis with IgnoreGuiInset = false already respect.
 local function GetCoreGuiInset(): (Vector2, Vector2)
     local Success, TopLeft, BottomRight = pcall(function()
         return GuiService:GetGuiInset()
@@ -1620,10 +1617,6 @@ local function GetCoreGuiInset(): (Vector2, Vector2)
     return Vector2.zero, Vector2.zero
 end
 
--- Computes the magnetic X/Y targets (screen Edges + Center) an element can snap to, keyed by name
--- so callers can tell exactly which Edge (or Center) matched. When AvoidCoreGui is true, the
--- "safe area" used for these targets excludes whatever space Roblox's own topbar currently
--- occupies, so Edges/Center land below and around it instead of underneath it.
 local function GetSnapEdges(ElemSize: Vector2, ViewportSize: Vector2, Margin: number, AvoidCoreGui: boolean)
     local SafeMin, SafeMax = Vector2.zero, ViewportSize
 
@@ -1647,7 +1640,6 @@ local function GetSnapEdges(ElemSize: Vector2, ViewportSize: Vector2, Margin: nu
     return TargetsX, TargetsY
 end
 
--- Finds the closest named target within Distance on a single axis, or nil if nothing is close enough.
 local function GetClosestSnapTarget(Value: number, Targets: { [string]: number }, Distance: number): (number?, string?)
     local ClosestName, ClosestValue, ClosestDist = nil, nil, Distance
 
@@ -1663,9 +1655,6 @@ local function GetClosestSnapTarget(Value: number, Targets: { [string]: number }
     return ClosestValue, ClosestName
 end
 
--- Converts a snapped axis value into the screen-space coordinate the guide line should be drawn
--- at, so it sits flush with the screen Edge (or through the true Center) rather than through the
--- middle of the dragged element.
 local function GetSnapGuideOffset(Name: string, SnappedValue: number, ElemDimension: number): number
     if Name == "RightEdge" or Name == "BottomEdge" then
         return SnappedValue + ElemDimension
@@ -1780,8 +1769,6 @@ function Library:MakeDraggable(
                 local Distance = SnapConfig.Distance or 28
                 local Margin = SnapConfig.Margin or 8
 
-                -- Resolve to absolute screen-space so Edges/Center line up regardless of the
-                -- element's current Scale anchor (e.g. a window that started Centered).
                 local AbsX = FramePos.X.Scale * ViewportSize.X + NewX
                 local AbsY = FramePos.Y.Scale * ViewportSize.Y + NewY
 


### PR DESCRIPTION
The window is currently only freely draggable with no positioning helpers, which makes it fiddly to consistently dock it in a corner or re-center it (especially after resizing the game window). This gives users fast, discoverable "snap points" without losing the ability to position the window anywhere.

___

## Details
Dragging the main `Obsidian` window now magnetically snaps to a 3×3 grid of suggested positions — `LeftEdge`/`Center`/`RightEdge` on the X axis and `TopEdge`/`Center`/`BottomEdge` on the Y axis — giving all 4 screen corners, the 4 edge midpoints, and dead-center as snap targets, similar to Windows' Aero Snap. Snapping is a suggestion, not a lock: it only pulls the window in when the cursor is within a configurable radius, so free positioning anywhere on screen is unaffected outside that radius.

New `Window` config, all optional with defaults:
- `Snapping` (bool, default `true`) — master toggle
- `SnapAvoidCoreGui` (bool, default `true`) — rescales snap targets based on currently visible `CoreGui` elements
- `SnapDistance` (number, default `28`) — magnet radius in pixels
- `SnapMargin` (number, default `8`) — gap kept from the screen edge when snapped

Also added `Window:SetSnapping(Enabled, Distance?, Margin?)` for runtime control, mirroring the existing `SetAlwaysOnTop` pattern.

```lua
local Window = Library:CreateWindow({
    Snapping = true,
    SnapAvoidCoreGui = true
    SnapDistance = 28,
    SnapMargin = 8,
})
```

### Implementation notes

- `Library:MakeDraggable` gained a 5th optional parameter, `SnapConfig: { Enabled, Distance?, Margin? }?`. All five existing calls (draggable labels, buttons, image buttons, the draggable-menu helper, and the loading screen) pass nothing, so their behavior is byte-for-byte unchanged — snapping only activates where `CreateWindow` opts in.
- Two new local helpers do the math: `GetSnapEdges` builds named X/Y target tables (`LeftEdge`/`Center`/`RightEdge`, `TopEdge`/`Center`/`BottomEdge`) from the element's size, viewport size, and margin; `GetClosestSnapTarget` finds the nearest named target within `Distance` per axis (axes snap independently, so any edge/center combination is reachable without hardcoding 9 cases).
- Snap math is done in absolute screen-space (`Scale * ViewportSize + Offset`) so it lines up correctly regardless of the window's current `Position` scale anchor — this matters because a centered window (`Window.Center = true`) starts with a `0.5` scale component that persists through drags.
- Added `AccentColor` guide lines (2px, faded) that appear flush with the true screen edge/centerline — not through the window's middle — while a snap is active, and hide on release. A small `GetSnapGuideOffset` helper converts a matched target into the correct guide coordinate depending on whether it's an edge (line sits at the boundary) or center (line sits at the midpoint).
- Guide frames are created lazily on first use and destroyed alongside the window's other drag connections in the existing `UI.Destroying` cleanup.
- **CoreGui avoidance:** the safe area used for snap targets is now `viewport minus GuiService:GetGuiInset()` rather than the raw viewport, gated behind `Window.SnapAvoidCoreGui` (default `true`). This pushes top-row snap targets below Roblox's topbar and re-balances Center within the reduced area, so the window doesn't snap to a position that's partially hidden behind Roblox's own UI. Note this only covers the topbar icon cluster (the only Core UI region Roblox exposes bounds for) — the expandable chat log and Team Create voice panel aren't covered, since their bounds aren't publicly queryable; `SnapMargin` can be increased as a manual buffer if that's an issue in practice.

<img width="800" height="427" alt="ezgif-89cc4383788fec2b" src="https://github.com/user-attachments/assets/32d446c7-e76b-40de-8cfc-919b79269bbd" />