### PR TITLE
Add automatic contrast checking for accessibility

### DIFF
--- a/addons/ThemeManager.lua
+++ b/addons/ThemeManager.lua
@@ -587,7 +587,7 @@ function ThemeManager:UpdateContrastWarning()
                     "Your %s has a contrast ratio of %.1f:1, below the recommended %.1f:1. Text may be hard to read.",
                     Report.PairName, Report.Ratio, CONTRAST_WARN_THRESHOLD
                 ),
-                Time = 6,
+                Time = 10,
             })
         end
     end

--- a/addons/ThemeManager.lua
+++ b/addons/ThemeManager.lua
@@ -31,9 +31,7 @@ end
 
 --// Theme Manager
 local SchemeIndexes = { "FontColor", "MainColor", "AccentColor", "BackgroundColor", "OutlineColor" }
-
---// Accessibility: minimum WCAG AA contrast ratio for normal text
-local CONTRAST_WARN_THRESHOLD = 4.5
+local ContrastWarnThreshold = 4.5 --// Accessibility: minimum WCAG AA contrast ratio for normal text
 
 local ThemeManager = {
     Library = nil,
@@ -145,12 +143,23 @@ local function IsValidFolderPath(Name: string): boolean
 end
 
 --// Contrast helpers \\--
+--// WCAG 2.x relative luminance / contrast constants (https://www.w3.org/TR/WCAG21/#dfn-relative-luminance)
+local SrgbLinearThreshold = 0.03928 --// sRGB channel value below which the linear conversion is a simple divide
+local SrgbLinearDivisor = 12.92 --// Divisor used for channel values below SrgbLinearThreshold
+local SrgbGammaOffset = 0.055 --// Offset applied before the gamma expansion power curve
+local SrgbGammaScale = 1.055 --// Scale applied before the gamma expansion power curve
+local SrgbGammaExponent = 2.4 --// Exponent for the gamma expansion power curve
+local LuminanceRedWeight = 0.2126 --// Red channel weight in the relative luminance formula
+local LuminanceGreenWeight = 0.7152 --// Green channel weight in the relative luminance formula
+local LuminanceBlueWeight = 0.0722 --// Blue channel weight in the relative luminance formula
+local ContrastRatioOffset = 0.05 --// Offset added to both luminances when computing a contrast ratio
+
 local function LinearizeChannel(Channel: number): number
-    if Channel <= 0.03928 then
-        return Channel / 12.92
+    if Channel <= SrgbLinearThreshold then
+        return Channel / SrgbLinearDivisor
     end
 
-    return ((Channel + 0.055) / 1.055) ^ 2.4
+    return ((Channel + SrgbGammaOffset) / SrgbGammaScale) ^ SrgbGammaExponent
 end
 
 local function GetRelativeLuminance(Color: Color3): number
@@ -158,7 +167,7 @@ local function GetRelativeLuminance(Color: Color3): number
     local G = LinearizeChannel(Color.G)
     local B = LinearizeChannel(Color.B)
 
-    return 0.2126 * R + 0.7152 * G + 0.0722 * B
+    return LuminanceRedWeight * R + LuminanceGreenWeight * G + LuminanceBlueWeight * B
 end
 
 local function GetContrastRatio(ColorA: Color3, ColorB: Color3): number
@@ -168,7 +177,9 @@ local function GetContrastRatio(ColorA: Color3, ColorB: Color3): number
     local Lighter = math.max(LuminanceA, LuminanceB)
     local Darker = math.min(LuminanceA, LuminanceB)
 
-    return (Lighter + 0.05) / (Darker + 0.05)
+    return (Lighter + ContrastRatioOffset) / (Darker + ContrastRatioOffset)
+end
+
 local function IsValidThemeData(Data: any): boolean
     if typeof(Data) ~= "table" then
         return false
@@ -566,7 +577,7 @@ function ThemeManager:GetContrastReport(): { Ratio: number, PairName: string, Pa
     return {
         Ratio = WorstRatio,
         PairName = WorstName,
-        Passes = WorstRatio >= CONTRAST_WARN_THRESHOLD,
+        Passes = WorstRatio >= ContrastWarnThreshold,
     }
 end
 
@@ -592,7 +603,7 @@ function ThemeManager:UpdateContrastWarning()
     else
         ContrastLabel:SetText(string.format(
             "Low contrast (%.1f:1) between %s. Aim for at least %.1f:1 so text stays readable.",
-            Report.Ratio, Report.PairName, CONTRAST_WARN_THRESHOLD
+            Report.Ratio, Report.PairName, ContrastWarnThreshold
         ))
 
         TextLabel.TextColor3 = Library.Scheme.RedColor
@@ -603,7 +614,7 @@ function ThemeManager:UpdateContrastWarning()
                 Title = "Low contrast theme",
                 Description = string.format(
                     "Your %s has a contrast ratio of %.1f:1, below the recommended %.1f:1. Text may be hard to read.",
-                    Report.PairName, Report.Ratio, CONTRAST_WARN_THRESHOLD
+                    Report.PairName, Report.Ratio, ContrastWarnThreshold
                 ),
                 Time = 10,
             })
@@ -888,7 +899,7 @@ function ThemeManager:CreateThemeManager(Themesbox: any)
             "Low contrast theme",
             string.format(
                 "This theme has a contrast ratio of %.1f:1 between %s, below the recommended %.1f:1. Text may be hard to read. Save anyway?",
-                Report.Ratio, Report.PairName, CONTRAST_WARN_THRESHOLD
+                Report.Ratio, Report.PairName, ContrastWarnThreshold
             ),
 
             "Save Anyway",

--- a/addons/ThemeManager.lua
+++ b/addons/ThemeManager.lua
@@ -31,6 +31,10 @@ end
 
 --// Theme Manager
 local SchemeIndexes = { "FontColor", "MainColor", "AccentColor", "BackgroundColor", "OutlineColor" }
+
+--// Accessibility: minimum WCAG AA contrast ratio for normal text
+local CONTRAST_WARN_THRESHOLD = 4.5
+
 local ThemeManager = {
     Library = nil,
 
@@ -38,6 +42,10 @@ local ThemeManager = {
 
     AppliedToTab = false,
     DefaultThemeName = nil,
+
+    --// Accessibility: contrast warning state
+    ContrastLabel = nil,
+    ContrastWasPoor = false,
 
     BuiltInThemes = {
         ["Default"] = {
@@ -134,6 +142,33 @@ local function IsValidFolderPath(Name: string): boolean
         not Name:match("^%s*$") and 
         not Name:find('[<>:"|%?%*%z]')
     )
+end
+
+--// Contrast helpers \\--
+local function LinearizeChannel(Channel: number): number
+    if Channel <= 0.03928 then
+        return Channel / 12.92
+    end
+
+    return ((Channel + 0.055) / 1.055) ^ 2.4
+end
+
+local function GetRelativeLuminance(Color: Color3): number
+    local R = LinearizeChannel(Color.R)
+    local G = LinearizeChannel(Color.G)
+    local B = LinearizeChannel(Color.B)
+
+    return 0.2126 * R + 0.7152 * G + 0.0722 * B
+end
+
+local function GetContrastRatio(ColorA: Color3, ColorB: Color3): number
+    local LuminanceA = GetRelativeLuminance(ColorA)
+    local LuminanceB = GetRelativeLuminance(ColorB)
+
+    local Lighter = math.max(LuminanceA, LuminanceB)
+    local Darker = math.min(LuminanceA, LuminanceB)
+
+    return (Lighter + 0.05) / (Darker + 0.05)
 end
 
 --// Folder helper \\--
@@ -484,6 +519,82 @@ function ThemeManager:DeleteDefaultTheme(): (boolean, string?)
     return true
 end
 
+--// Accessibility: contrast checking \\--
+function ThemeManager:GetContrastReport(): { Ratio: number, PairName: string, Passes: boolean }
+    local Library = ThemeManager.Library
+    local FontColorOption = Library.Options.FontColor
+    local BackgroundColorOption = Library.Options.BackgroundColor
+    local MainColorOption = Library.Options.MainColor
+
+    if not (FontColorOption and BackgroundColorOption and MainColorOption) then
+        return { Ratio = math.huge, PairName = "", Passes = true }
+    end
+
+    local FontColor = FontColorOption.Value
+    local Surfaces = {
+        { Name = "font color vs. background color", Color = BackgroundColorOption.Value },
+        { Name = "font color vs. main color", Color = MainColorOption.Value },
+    }
+
+    local WorstRatio, WorstName = math.huge, ""
+    for _, Surface in Surfaces do
+        local Ratio = GetContrastRatio(FontColor, Surface.Color)
+        if Ratio < WorstRatio then
+            WorstRatio = Ratio
+            WorstName = Surface.Name
+        end
+    end
+
+    return {
+        Ratio = WorstRatio,
+        PairName = WorstName,
+        Passes = WorstRatio >= CONTRAST_WARN_THRESHOLD,
+    }
+end
+
+function ThemeManager:UpdateContrastWarning()
+    local ContrastLabel = ThemeManager.ContrastLabel
+    if not ContrastLabel or ContrastLabel.Destroyed then
+        return
+    end
+
+    local Library = ThemeManager.Library
+    local Report = ThemeManager:GetContrastReport()
+    local TextLabel = ContrastLabel.TextLabel
+
+    if not Library.Registry[TextLabel] then
+        Library:AddToRegistry(TextLabel, {})
+    end
+
+    if Report.Passes then
+        ContrastLabel:SetText(string.format("Contrast check: good (%.1f:1)", Report.Ratio))
+
+        TextLabel.TextColor3 = Library.Scheme.FontColor
+        Library.Registry[TextLabel].TextColor3 = "FontColor"
+    else
+        ContrastLabel:SetText(string.format(
+            "Low contrast (%.1f:1) between %s. Aim for at least %.1f:1 so text stays readable.",
+            Report.Ratio, Report.PairName, CONTRAST_WARN_THRESHOLD
+        ))
+
+        TextLabel.TextColor3 = Library.Scheme.RedColor
+        Library.Registry[TextLabel].TextColor3 = "RedColor"
+
+        if not ThemeManager.ContrastWasPoor then
+            Library:Notify({
+                Title = "Low contrast theme",
+                Description = string.format(
+                    "Your %s has a contrast ratio of %.1f:1, below the recommended %.1f:1. Text may be hard to read.",
+                    Report.PairName, Report.Ratio, CONTRAST_WARN_THRESHOLD
+                ),
+                Time = 6,
+            })
+        end
+    end
+
+    ThemeManager.ContrastWasPoor = not Report.Passes
+end
+
 --// Apply Theme \\--
 function ThemeManager:ThemeUpdate()
     local Library = ThemeManager.Library
@@ -496,6 +607,7 @@ function ThemeManager:ThemeUpdate()
     end
 
     Library:UpdateColorsUsingRegistry()
+    ThemeManager:UpdateContrastWarning()
 end
 
 function ThemeManager:ApplyTheme(ThemeName: string)
@@ -625,7 +737,13 @@ function ThemeManager:CreateThemeManager(Themesbox: any)
     local AccentColor = CreateColorOption("Accent color", "AccentColor")
     local OutlineColor = CreateColorOption("Outline color", "OutlineColor")
     local FontColor = CreateColorOption("Font color", "FontColor")
-    
+
+    --// Accessibility: live contrast readout for the colors above
+    ThemeManager.ContrastLabel = Themesbox:AddLabel({
+        Text = "Contrast check: n/a",
+        DoesWrap = true,
+    })
+
     Themesbox:AddDropdown("FontFace", {
         Text = "Font Face",
         Default = "Code",
@@ -683,6 +801,41 @@ function ThemeManager:CreateThemeManager(Themesbox: any)
         Text = "Custom theme name" 
     })
 
+    local function SaveThemeWithContrastCheck(Name: string, SuccessMessage: string, OnSaved: (() -> nil)?)
+        local function DoSave()
+            local Success, ErrorMessage = ThemeManager:SaveCustomTheme(Name)
+            if not Success then
+                ThemeManager.Library:Notify(string.format("Failed to save theme %q: %s", Name, ErrorMessage))
+                return
+            end
+
+            ThemeManager.Library:Notify(string.format(SuccessMessage, Name))
+            if OnSaved then OnSaved() end
+        end
+
+        local Report = ThemeManager:GetContrastReport()
+        if Report.Passes then
+            DoSave()
+            return
+        end
+
+        ShowDialog(
+            function(): boolean
+                return true
+            end,
+
+            "ThemeManager_LowContrastSave",
+            "Low contrast theme",
+            string.format(
+                "This theme has a contrast ratio of %.1f:1 between %s, below the recommended %.1f:1. Text may be hard to read. Save anyway?",
+                Report.Ratio, Report.PairName, CONTRAST_WARN_THRESHOLD
+            ),
+
+            "Save Anyway",
+            DoSave
+        )
+    end
+
     Themesbox:AddButton("Create theme", function()
         local Name = CustomThemeName.Value
         if IsStringEmpty(Name) then
@@ -706,14 +859,7 @@ function ThemeManager:CreateThemeManager(Themesbox: any)
 
             "Overwrite",
             function()
-                local Success, ErrorMessage = ThemeManager:SaveCustomTheme(Name)
-                if not Success then
-                    ThemeManager.Library:Notify(string.format("Failed to create theme %q: %s", Name, ErrorMessage))
-                    return
-                end
-
-                ThemeManager.Library:Notify(string.format("Successfully created theme %q", Name))
-                RefreshList()
+                SaveThemeWithContrastCheck(Name, "Successfully created theme %q", RefreshList)
             end
         )
     end)
@@ -772,8 +918,7 @@ function ThemeManager:CreateThemeManager(Themesbox: any)
 
             "Overwrite",
             function()
-                ThemeManager:SaveCustomTheme(Name)
-                ThemeManager.Library:Notify(string.format("Successfully overwrote theme %q", Name))
+                SaveThemeWithContrastCheck(Name, "Successfully overwrote theme %q")
             end
         )
     end)
@@ -875,6 +1020,7 @@ function ThemeManager:CreateThemeManager(Themesbox: any)
 
     --// Load default
     ThemeManager:LoadDefault()
+    ThemeManager:UpdateContrastWarning()
     ThemeManager.AppliedToTab = true
     RefreshDefaultThemeLabel()
 

--- a/addons/ThemeManager.lua
+++ b/addons/ThemeManager.lua
@@ -29,9 +29,20 @@ if isfolder_success == false or typeof(isfolder_error) ~= "boolean" then
     end
 end
 
+--// WCAG21 constants (https://www.w3.org/TR/WCAG21/#dfn-relative-luminance)
+local ContrastWarnThreshold = 4.5 --// Accessibility: minimum WCAG AA contrast ratio for normal text
+local SrgbLinearThreshold = 0.03928 --// sRGB channel value below which the linear conversion is a simple divide
+local SrgbLinearDivisor = 12.92 --// Divisor used for channel values below SrgbLinearThreshold
+local SrgbGammaOffset = 0.055 --// Offset applied before the gamma expansion power curve
+local SrgbGammaScale = 1.055 --// Scale applied before the gamma expansion power curve
+local SrgbGammaExponent = 2.4 --// Exponent for the gamma expansion power curve
+local LuminanceRedWeight,
+      LuminanceGreenWeight,
+      LuminanceBlueWeight = 0.2126, 0.7152, 0.0722 --// R, G, B channel weights in the relative luminance formula
+local ContrastRatioOffset = 0.05 --// Offset added to both luminances when computing a contrast ratio
+
 --// Theme Manager
 local SchemeIndexes = { "FontColor", "MainColor", "AccentColor", "BackgroundColor", "OutlineColor" }
-local ContrastWarnThreshold = 4.5 --// Accessibility: minimum WCAG AA contrast ratio for normal text
 
 local ThemeManager = {
     Library = nil,
@@ -143,17 +154,6 @@ local function IsValidFolderPath(Name: string): boolean
 end
 
 --// Contrast helpers \\--
---// WCAG 2.x relative luminance / contrast constants (https://www.w3.org/TR/WCAG21/#dfn-relative-luminance)
-local SrgbLinearThreshold = 0.03928 --// sRGB channel value below which the linear conversion is a simple divide
-local SrgbLinearDivisor = 12.92 --// Divisor used for channel values below SrgbLinearThreshold
-local SrgbGammaOffset = 0.055 --// Offset applied before the gamma expansion power curve
-local SrgbGammaScale = 1.055 --// Scale applied before the gamma expansion power curve
-local SrgbGammaExponent = 2.4 --// Exponent for the gamma expansion power curve
-local LuminanceRedWeight = 0.2126 --// Red channel weight in the relative luminance formula
-local LuminanceGreenWeight = 0.7152 --// Green channel weight in the relative luminance formula
-local LuminanceBlueWeight = 0.0722 --// Blue channel weight in the relative luminance formula
-local ContrastRatioOffset = 0.05 --// Offset added to both luminances when computing a contrast ratio
-
 local function LinearizeChannel(Channel: number): number
     if Channel <= SrgbLinearThreshold then
         return Channel / SrgbLinearDivisor


### PR DESCRIPTION
Custom themes currently have no checks to prevent unreadable color combos (e.g.
white text on a near-white background). This is an accessibility gap
users could hit accidentally while tweaking colors, with no feedback
until they actually looked at their UI.

___

## Details
Added [WCAG](https://www.w3.org/WAI/standards-guidelines/wcag/)-based contrast checking across three points, layered
so it's informative without being spammy:

- **Live label** — a new label under the color pickers recalculates
  on every color change and shows the current contrast ratio
  (`Contrast check: good (X.X:1)` / `Low contrast (X.X:1)...`),
  turning red on failure using the existing `RedColor`/registry
  pattern.
- **Edge-triggered notification** — `Library:Notify(...)` only fires
  the moment contrast *crosses into* failing, not on every drag tick
  of the color picker (which fires continuously). Won't re-notify
  until the user fixes it and breaks it again.
- **Save-time confirmation dialog** — "Create theme" and "Overwrite
  theme" now route through a shared `SaveThemeWithContrastCheck`
  helper that blocks the save behind a `ShowDialog` confirmation
  ("Save anyway?") if contrast fails, reusing the same dialog pattern
  as the existing overwrite/delete confirmations.

## Implementation notes

- Contrast math is the standard [WCAG](https://www.w3.org/WAI/standards-guidelines/wcag/) relative-luminance formula
  (`GetRelativeLuminance` / `GetContrastRatio`), checked against
  **font vs. background** and **font vs. main color** (text sits on
  both surfaces), using the worse of the two.
- Threshold is `CONTRAST_WARN_THRESHOLD = 4.5` ([WCAG](https://www.w3.org/WAI/standards-guidelines/wcag/) AA, normal text).
- `ThemeManager:GetContrastReport()` is the single source of truth
  used by all three points, so the label, notification, and
  save dialog can never disagree.
- Verified the luminance/contrast math against an independent
  implementation (black/white = 21:1, white/white = 1:1, etc. —
  standard [WCAG](https://www.w3.org/WAI/standards-guidelines/wcag/) reference values).

## Media
### Default `Obsidian` theme
<img width="244" height="197" alt="image" src="https://github.com/user-attachments/assets/5ff2c8e5-9119-47dc-82ec-09de72a50cc8" />

### Full white `Background color` and `Font color`
<img width="247" height="250" alt="image" src="https://github.com/user-attachments/assets/0c886180-1d43-48fc-8049-f7107e094bbd" />

### Light gray-ish `Background color` and full white `Background color`

<img width="249" height="241" alt="image" src="https://github.com/user-attachments/assets/96a2bc8f-ad00-49d5-b378-d138d6e28921" />

<img width="305" height="111" alt="image" src="https://github.com/user-attachments/assets/8095c5f3-f815-4b76-ad49-068194d5ca66" />

<img width="404" height="173" alt="image" src="https://github.com/user-attachments/assets/23a5e5be-b533-44f6-838d-028417f05206" />

### Full white `Font color` and full white `Main color`

<img width="246" height="239" alt="image" src="https://github.com/user-attachments/assets/d5cdfe89-09a7-4dee-90e6-70fcbc39020b" />

<img width="303" height="115" alt="image" src="https://github.com/user-attachments/assets/0b87969c-f9e6-473c-98dc-61c0eb9424bd" /> (i know the text is illegible, but this just shows the notification is sent when the contrast is too low. just like the image above did)

<img width="408" height="161" alt="image" src="https://github.com/user-attachments/assets/d7a5f5de-0a0d-41af-89b0-075e47465ac6" />