### PR TITLE
Fix dropdown/context menu edge misalignment and scrollbar flicker

### DIFF
--- a/Library.lua
+++ b/Library.lua
@@ -1425,12 +1425,14 @@ function Library:SetDPIScale(DPIScale: number)
         UIScale.Scale = Library.DPIScale - (tonumber(Library.ScalesOffset[UIScale]) or 0)
     end
 
-    for _, Option in Options do
-        if Option.Type == "Dropdown" then
-            Option:RecalculateListSize()
-            Option:RefreshPool()
+    task.defer(function()
+        for _, Option in Options do
+            if Option.Type == "Dropdown" then
+                Option:RecalculateListSize()
+                Option:RefreshPool()
+            end
         end
-    end
+    end)
 
     for _, Notification in Library.Notifications do
         Notification:Resize()
@@ -3465,6 +3467,7 @@ function Library:AddContextMenu(
         Signal = nil,
 
         Size = Size,
+        Offset = Offset,
         AutoSizeY = List == 1,
 
         OpenCloseTween = nil,
@@ -3487,6 +3490,26 @@ function Library:AddContextMenu(
         })
     end
 
+    local function SetPosition()
+        local OffsetValue = typeof(Table.Offset) == "function" and Table.Offset() or Table.Offset
+
+        Menu.Position = UDim2.fromOffset(
+            math.floor(Holder.AbsolutePosition.X + OffsetValue[1]),
+            math.floor(Holder.AbsolutePosition.Y + OffsetValue[2])
+        )
+    end
+
+    local function SetSize()
+        local TargetSize = typeof(Table.Size) == "function" and Table.Size() or Table.Size
+
+        Menu.Size = UDim2.new(
+            TargetSize.X.Scale,
+            math.round(TargetSize.X.Offset),
+            TargetSize.Y.Scale,
+            math.round(TargetSize.Y.Offset)
+        )
+    end
+
     function Table:Open()
         if CurrentMenu == Table then
             return
@@ -3502,19 +3525,15 @@ function Library:AddContextMenu(
         Menu.Parent = nil
         Menu.Parent = TargetParent
 
-        if typeof(Offset) == "function" then
-            Menu.Position = UDim2.fromOffset(
-                math.floor(Holder.AbsolutePosition.X + Offset()[1]),
-                math.floor(Holder.AbsolutePosition.Y + Offset()[2])
-            )
-        else
-            Menu.Position = UDim2.fromOffset(
-                math.floor(Holder.AbsolutePosition.X + Offset[1]),
-                math.floor(Holder.AbsolutePosition.Y + Offset[2])
-            )
-        end
+        SetPosition()
 
         local TargetSize = typeof(Table.Size) == "function" and Table.Size() or Table.Size
+        TargetSize = UDim2.new(
+            TargetSize.X.Scale,
+            math.round(TargetSize.X.Offset),
+            TargetSize.Y.Scale,
+            math.round(TargetSize.Y.Offset)
+        )
 
         if typeof(ActiveCallback) == "function" then
             Library:SafeCallback(ActiveCallback, true)
@@ -3558,22 +3577,18 @@ function Library:AddContextMenu(
 
             Tween:Play()
         else
-            Menu.Size = TargetSize
+            SetSize()
             Menu.Visible = true
         end
 
-        Table.Signal = Holder:GetPropertyChangedSignal("AbsolutePosition"):Connect(function()
-            if typeof(Offset) == "function" then
-                Menu.Position = UDim2.fromOffset(
-                    math.floor(Holder.AbsolutePosition.X + Offset()[1]),
-                    math.floor(Holder.AbsolutePosition.Y + Offset()[2])
-                )
-            else
-                Menu.Position = UDim2.fromOffset(
-                    math.floor(Holder.AbsolutePosition.X + Offset[1]),
-                    math.floor(Holder.AbsolutePosition.Y + Offset[2])
-                )
+        Table.SizeSignal = Holder:GetPropertyChangedSignal("AbsoluteSize"):Connect(function()
+            if not Table.AutoSizeY then
+                SetSize()
             end
+        end)
+
+        Table.Signal = Holder:GetPropertyChangedSignal("AbsolutePosition"):Connect(function()
+            SetPosition()
 
             local HolderAllowed = Library:IsInsideFrame(Library.WindowContainer, Holder)
             if not HolderAllowed then
@@ -3591,6 +3606,10 @@ function Library:AddContextMenu(
                 Table:Close()
             end
         end)
+
+        task.defer(function()
+            print(string.format("[CM final] %s | DPIScale=%.3f | HolderAbsPos=%s HolderAbsSize=%s | MenuPos=%s MenuAbsPos=%s MenuAbsSize=%s | MenuParent=%s",Holder:GetFullName(),Library.DPIScale,tostring(Holder.AbsolutePosition), tostring(Holder.AbsoluteSize),tostring(Menu.Position), tostring(Menu.AbsolutePosition), tostring(Menu.AbsoluteSize),Menu.Parent and Menu.Parent:GetFullName() or "nil"))
+        end)
     end
 
     function Table:Close()
@@ -3601,6 +3620,11 @@ function Library:AddContextMenu(
         if Table.Signal then
             Table.Signal:Disconnect()
             Table.Signal = nil
+        end
+
+        if Table.SizeSignal then
+            Table.SizeSignal:Disconnect()
+            Table.SizeSignal = nil
         end
 
         Table.Active = false
@@ -3659,7 +3683,12 @@ function Library:AddContextMenu(
 
     function Table:SetSize(Size)
         Table.Size = Size
-        Menu.Size = typeof(Size) == "function" and Size() or Size
+        SetSize()
+    end
+
+    function Table:SetPosition(Offset)
+        Table.Offset = Offset
+        SetPosition()
     end
 
     function Table:Destroy()
@@ -8102,14 +8131,21 @@ do
             return ValueImage
         end
 
+        local function GetAlignedWidth()
+            local Left = math.floor(DisplayContainer.AbsolutePosition.X + 0.5)
+            local Right = math.floor(DisplayContainer.AbsolutePosition.X + 0.5 + DisplayContainer.AbsoluteSize.X)
+
+            return (Right - Left) / Library.DPIScale
+        end
+
         local MenuTable
         MenuTable = Library:AddContextMenu(
             DisplayContainer,
             function()
-                return UDim2.fromOffset((DisplayContainer.AbsoluteSize.X / Library.DPIScale), 0)
+                return UDim2.fromOffset(GetAlignedWidth(), 0)
             end,
             function()
-                return { 0.5, DisplayContainer.AbsoluteSize.Y + 1.5 }
+                return { 0.5, DisplayContainer.AbsoluteSize.Y + 1 }
             end,
             2,
             function(Active: boolean)
@@ -8158,7 +8194,7 @@ do
             MenuTable.Menu.ScrollBarThickness = (ItemCount * ItemHeight > Y) and 2 or 0
 
             MenuTable:SetSize(function()
-                return UDim2.fromOffset((DisplayContainer.AbsoluteSize.X / Library.DPIScale), Y)
+                return UDim2.fromOffset(GetAlignedWidth(), Y)
             end)
         end
 

--- a/Library.lua
+++ b/Library.lua
@@ -8155,6 +8155,7 @@ do
             local Y = math.clamp(ItemCount * ItemHeight, 0, Info.MaxVisibleDropdownItems * ItemHeight)
 
             MenuTable.Menu.CanvasSize = UDim2.fromOffset(0, ItemCount * ItemHeight)
+            MenuTable.Menu.ScrollBarThickness = (ItemCount * ItemHeight > Y) and 2 or 0
 
             MenuTable:SetSize(function()
                 return UDim2.fromOffset((DisplayContainer.AbsoluteSize.X / Library.DPIScale), Y)

--- a/Library.lua
+++ b/Library.lua
@@ -3606,10 +3606,6 @@ function Library:AddContextMenu(
                 Table:Close()
             end
         end)
-
-        task.defer(function()
-            print(string.format("[CM final] %s | DPIScale=%.3f | HolderAbsPos=%s HolderAbsSize=%s | MenuPos=%s MenuAbsPos=%s MenuAbsSize=%s | MenuParent=%s",Holder:GetFullName(),Library.DPIScale,tostring(Holder.AbsolutePosition), tostring(Holder.AbsoluteSize),tostring(Menu.Position), tostring(Menu.AbsolutePosition), tostring(Menu.AbsoluteSize),Menu.Parent and Menu.Parent:GetFullName() or "nil"))
-        end)
     end
 
     function Table:Close()


### PR DESCRIPTION
## Summary
Two related bugs in the dropdown's flyout menu (built on
`AddContextMenu`):
1. The list's right edge could land up to 1px off the button's own
   right edge — visible as a small square notch at the top-right
   corner while the list is open (that corner has 0 radius, so
   unlike the bottom corners, the gap isn't hidden by rounding).
#### Dropdown on the left side vs. right side of a tab - 1 pixel off vs. 0 pixels off (you might have to open the images and zoom in)
<img width="23" height="139" alt="left" src="https://github.com/user-attachments/assets/454a5ceb-6ea2-4bcd-9622-c3bc292a620e" />
<img width="23" height="123" alt="right" src="https://github.com/user-attachments/assets/d0cfa643-74f4-4aa6-8ccc-d3bdd439f37f" />

2. A scrollbar "flicker" every time a dropdown is opened. - look at the right side of the dropdown list, where the scrollbar would be
<img width="800" height="347" alt="ezgif-198ac6fe96526df4" src="https://github.com/user-attachments/assets/512e09bf-65bc-4844-844a-60e0a4e7418e" />

## 1. List-edge misalignment
deividcomsono flagged the 1px gap in review and requested:
round the size with `math.round`, pull the size/position-assignment
logic into local `SetSize`/`SetPosition` helpers so `AddContextMenu`
stops repeating the same statements in multiple places, and have
any global setter assign the `Table` property first, then call the
local helper.

Implemented as requested in #175:
- `AddContextMenu` now has local `SetSize()` / `SetPosition()`
  helpers, used in `Open()`, in the `AbsoluteSize`/
  `AbsolutePosition`-changed listeners, and in the global setters
  `Table:SetSize` / `Table:SetPosition` (new) — each sets its
  `Table` property first, then calls the matching local helper.
- `Menu.Size` is now rounded with `math.round`.

That surfaced the actual root cause: the dropdown list's width and
`Menu.Position.X` were being rounded independently. Independently
rounded numbers don't stay aligned — `round(A) + round(B)` isn't
guaranteed to equal `round(A + B)` — so the list's right edge could
miss the button's right edge by a pixel, and which side it showed
up on depended on that specific button's sub-pixel
`AbsolutePosition.X` (left and right-tab buttons sit at different
X coordinates, hence the left/right asymmetry).

Fixed by deriving the list's width from the same rounded left/right
edges used for position, instead of rounding the raw width on its
own. Applied in both the dropdown's `Size` callback and
`Dropdown:RecalculateListSize`, which recalculates width on every
open and every search-filter pass and was silently reverting to
the old, unaligned formula each time.

## 2. Scrollbar flicker on open
The scrollbar attempts to add itself inside dropdown lists even
when the list doesn't have enough entries, and not needing a scrollbar.

`ScrollBarThickness` is set based on whether the filtered entry
count actually exceeds `MaxVisibleDropdownItems`, calculated
in `RecalculateListSize` before the size is applied — so the
scrollbar no longer briefly flashes on during the open animation
only to disappear once the list settles.

## Testing
- Verified list-edge alignment on dropdowns in both left and
right-side groupboxes.
- Randomized simulation of the edge-rounding formula
against `Menu.Position.X`'s own formula — zero mismatches.
- Verified scrollbar thickness toggling on dropdowns with entry
counts both above and below `MaxVisibleDropdownItems`.