### PR TITLE
Add KeyPicker:SetNoUI and SetDisabled

### DIFF
--- a/Library.lua
+++ b/Library.lua
@@ -589,6 +589,7 @@ local Templates = {
         Mode = "Toggle",
         Modes = { "Always", "Toggle", "Hold" },
         SyncToggleState = false,
+        NoUI = false,
 
         Callback = function() end,
         ChangedCallback = function() end,
@@ -3890,6 +3891,7 @@ do
             Toggled = false,
             Mode = Info.Mode,
             SyncToggleState = Info.SyncToggleState,
+            NoUI = Info.NoUI == true,
 
             Callback = Info.Callback,
             ChangedCallback = Info.ChangedCallback,
@@ -4214,7 +4216,7 @@ do
                 BackgroundTransparency = 1,
                 Size = UDim2.new(1, 0, 0, 16),
                 Text = "",
-                Visible = not Info.NoUI,
+                Visible = not KeyPicker.NoUI,
                 Parent = Library.KeybindContainer,
             })
 
@@ -4282,7 +4284,7 @@ do
 
             KeyPicker.DoClick = function(...) end --// make luau lsp shut up
             table.insert(KeyPicker.Connections, Holder.MouseButton1Click:Connect(function()
-                if KeybindsToggle.Normal then
+                if KeybindsToggle.Normal or KeyPicker.NoUI then
                     return
                 end
 
@@ -4568,23 +4570,27 @@ do
 
         function KeyPicker:Update()
             local Disabled = ParentObj.Disabled == true
+            local Inert = Disabled or KeyPicker.NoUI
 
-            if Disabled and Picking then
+            if Inert and Picking then
                 SetPickingState(false, true)
             end
 
             KeyPicker:Display()
 
-            Picker.Active = not Disabled
-            ApplyPickerTextTransparency(Disabled and 0.8 or 0.4)
+            Picker.Active = not Inert
+            ApplyPickerTextTransparency(Inert and 0.8 or 0.4)
 
-            if Disabled then
+            if Inert then
                 if MenuTable.Active then
                     MenuTable:Close()
                 end
             end
 
-            if Info.NoUI then
+            if KeyPicker.NoUI then
+                if KeybindsToggle.Loaded then
+                    KeybindsToggle:SetVisibility(false)
+                end
                 return
             end
 
@@ -4654,7 +4660,7 @@ do
         end
 
         function KeyPicker:DoClick()
-            if Picking or ParentObj.Disabled then
+            if Picking or ParentObj.Disabled or KeyPicker.NoUI then
                 return
             end
 
@@ -4683,7 +4689,7 @@ do
         end
 
         function KeyPicker:RunChanged(IsKeyValid, KeyCode)
-            if ParentObj.Disabled then
+            if ParentObj.Disabled or KeyPicker.NoUI then
                 return
             end
 
@@ -4749,8 +4755,19 @@ do
             KeyPicker:Update()
         end
 
+        function KeyPicker:SetNoUI(NoUI: boolean)
+            NoUI = NoUI == true
+
+            if KeyPicker.NoUI == NoUI then
+                return
+            end
+
+            KeyPicker.NoUI = NoUI
+            KeyPicker:Update()
+        end
+
         table.insert(KeyPicker.Connections, Picker.MouseButton1Click:Connect(function()
-            if Picking or Library.IsPicking or ParentObj.Disabled then
+            if Picking or Library.IsPicking or ParentObj.Disabled or KeyPicker.NoUI then
                 return
             end
 
@@ -4903,7 +4920,7 @@ do
         end))
 
         table.insert(KeyPicker.Connections, Picker.MouseButton2Click:Connect(function()
-            if ParentObj.Disabled then
+            if ParentObj.Disabled or KeyPicker.NoUI then
                 return
             end
 
@@ -4918,6 +4935,7 @@ do
             local IsMouse = IsMouseClickInput(Input)
             if
                 ParentObj.Disabled
+                or KeyPicker.NoUI
                 or KeyPicker.Mode == "Always"
                 or KeyPicker.Value == "Unknown"
                 or KeyPicker.Value == "None"
@@ -4966,6 +4984,7 @@ do
             local IsMouse = IsMouseClickInput(Input)
             if
                 ParentObj.Disabled
+                or KeyPicker.NoUI
                 or KeyPicker.Value == "Unknown"
                 or KeyPicker.Value == "None"
                 or Picking


### PR DESCRIPTION
This PR is an updated variant of #176 (`Add KeyPicker:SetNoUI`), based on the replies from @deividcomsono on September 1st, which I didn't happen to notice until now, when I was updating my PR branches for both Obsidian and MSESP.

## Problem

There was no way to hide a keybind from the Keybinds frame at
runtime, and no way to disable a keybind's input/callbacks on
its own — separately from disabling its whole parent element. The
`Info.NoUI` option only hid the entry once at construction and
never touched input handling, so a script couldn't dynamically hide
a KeyPicker's UI without also fully controlling the parent, and
there was no equivalent of `Toggle:SetDisabled`/`Button:SetDisabled`
for keybinds at all.

## Changes

- Converted `Info.NoUI` from a static, init-only closure value to a
changeable `KeyPicker.NoUI` field, and added `KeyPicker:SetNoUI(bool)`
so it can be toggled at any point after creation, matching the
pattern of other KeyPicker setters (`SetValue`, `SetText`). `NoUI`
only controls whether the keybind's entry is shown in the Keybinds
frame — it has no effect on input or callbacks.
- `KeyPicker:Update()` now actively shows/hides the `KeybindsToggle`
entry based on `KeyPicker.NoUI` (alongside the existing
`MenuVisible` flag) instead of only respecting it once at creation.
- Added a new `KeyPicker.Disabled` field and `KeyPicker:SetDisabled(bool)`,
matching the `SetDisabled` pattern already used by `Toggle`, `Button`,
and `Input`. Setting `Disabled`:
  - dims the picker and sets `Picker.Active = false`, reusing the
  existing "parent disabled" `Inert` styling/behavior
  - closes the mode menu and cancels any in-progress key-picking
  - blocks the `UserInputService.InputBegan` listener from processing
  the bound key, so the toggle state can't change internally
  - suppresses `DoClick`, `RunChanged`, the picker's
  `MouseButton1Click`/`MouseButton2Click` handlers, and the entry's
  own click handler, as defense in depth so `Callback`, `Clicked`,
  `Changed`, and `ChangedCallback` are fully suppressed regardless
  of entry point
- Added `NoUI = false` and `Disabled = false` to `Templates.KeyPicker`
for discoverability/documentation consistency with the rest of the
option fields.

### `KeyPicker:SetNoUI`

<img width="800" height="287" alt="ezgif-2da54fdce22c175e" src="https://github.com/user-attachments/assets/ccccfc0b-fc1e-4b09-b595-0097ea73c2f7" />

### `KeyPicker:SetDisabled`
#### (The Keybind is being constantly triggered here, always pressing the `F` key on `Toggle` mode, with the Keybind's `Disabled` state being toggled every second)
<img width="800" height="280" alt="ezgif-4d8d748c2b34e266" src="https://github.com/user-attachments/assets/b6d4f3d0-ac45-4db9-9dfe-b36d30761e5b" />

## Notes

- `NoUI` and `Disabled` are independent: a keybind can be hidden
from the Keybinds frame while still fully functional, or disabled
while still visible there.
- `SetValue()` calls made while `Disabled` is active still update
`KeyPicker.Value` internally but won't fire `Changed`/
`ChangedCallback`.